### PR TITLE
[Phase 0.5 / 0.5.2.bump] AUTONOMOUS_PROTOCOL §14c + plan update + web 1.0.0 → 1.0.1

### DIFF
--- a/docs/plans/client-migration/AUTONOMOUS_PROTOCOL.md
+++ b/docs/plans/client-migration/AUTONOMOUS_PROTOCOL.md
@@ -609,6 +609,32 @@ Flow:
 6. `npm install` in client
 7. Commit client version bump
 
+### Mid-phase pre-consume bump
+
+Invoked interactively when a client lane in the current phase **consumes** a DS addition (new component, new icon, new token) that was added by an earlier lane in the same phase. Without a bump between the producing DS lane and the consuming client lane, the client's lockfile-pinned DS version predates the addition, so the consuming lane's typecheck fails in CI even though DS `main` has the API.
+
+The bump is structurally identical to §14b (phase-end); it just fires earlier.
+
+Skill: `ds-phase-end-bump` (same skill, invoked mid-phase).
+
+Flow:
+1. Confirm the producing DS lane is merged to DS `main` and the addition is present in `packages/web/src/components/icon/registry.ts` (or the relevant source)
+2. Bump `@umichkisa-ds/web` **patch** version in `packages/web/package.json` (mid-phase bumps are always patch; minor/major bumps wait for phase end)
+3. Append to `docs/plans/client-migration/ds-fixes-log.md` with the "mid-phase" marker
+4. Commit + tag `web-vX.Y.Z`
+5. Push tag → GitHub Actions publishes to npm
+6. Update `KISA-website/client/package.json` to pinned new version
+7. `npm install` in client → lockfile syncs to new version
+8. Commit client version bump on a short-lived branch; open PR titled `chore(deps): bump @umichkisa-ds/web to X.Y.Z (mid-phase pre-consume for lane <id>)`
+
+When to schedule at plan-writing time:
+
+- If any lane's acceptance criteria reference a DS API added by an earlier lane in the same phase, insert a "Mid-phase bump" step in `plan.md` **immediately after** the producing DS lane and **before** the consuming client lane.
+- The consuming client lane then depends on the bump lane via `blocked-by:<issue-#>` (treat the mid-phase bump as a real lane with its own issue).
+- All bump lanes are `needs-interactive` — publish is hard-denied for autonomous per §9.
+
+Omission recovery: if plan-writing missed the mid-phase bump and the autonomous routine hits the gap (as happened for lane 0.5.5 on 2026-04-18), the consuming lane bails out with `needs-decision` per §6, you run the mid-phase bump interactively, then relabel the draft PR `needs-revision` so the next routine run finishes it.
+
 ---
 
 ## 15. Skills Referenced
@@ -691,3 +717,4 @@ Each lever trades complexity for speed or quality. Pick when the complexity stop
 |---|---|---|
 | 2026-04-17 | Initial draft (13 AP questions + 3 follow-ups) | Phase 0.5 kickoff |
 | 2026-04-17 | Add post-merge label cleanup rule (§2, §8) — strip `ready-for-review` / `needs-revision` / `needs-decision` / `routine-errored` from PRs at merge time, since closed state replaces them | Surfaced during lane 0.5.2 review (PR #2 was merged with stale `ready-for-review` label) |
+| 2026-04-18 | Add §14c "Mid-phase pre-consume bump" — when a client lane consumes a DS addition produced by an earlier lane in the same phase, schedule an interactive patch-bump lane between them so the consuming lane's CI can install the new DS version | Surfaced during lane 0.5.5 autonomous run (PR #59): `instagram-brand` was on DS `main` after lane 0.5.2 merged, but the client pin was still `1.0.0` so the Icon name literal-type check failed in CI; §14b handles only phase-end bumps, leaving no legal path to unblock mid-phase |

--- a/docs/plans/client-migration/ds-fixes-log.md
+++ b/docs/plans/client-migration/ds-fixes-log.md
@@ -9,6 +9,7 @@ Accumulator for DS fixes made during client migration. Grouped by package, entri
 
 - **[Phase 0.5.2]** Add `instagram` custom icon (monochrome, `fill="currentColor"`) to icon registry — 2026-04-17
 - **[Phase 0.5.2]** Add `instagram-brand` custom icon (official gradient variant) to icon registry — 2026-04-17
+- **[Phase 0.5.2.bump, mid-phase]** Bump `@umichkisa-ds/web` `1.0.0 → 1.0.1` (patch, pre-consume for lane 0.5.5 Footer's `instagram-brand` usage) — 2026-04-18 — per `AUTONOMOUS_PROTOCOL.md` §14c
 
 ## @umichkisa-ds/form
 

--- a/docs/plans/client-migration/phase-0.5-layout/plan.md
+++ b/docs/plans/client-migration/phase-0.5-layout/plan.md
@@ -14,6 +14,8 @@ Wave 1:  0.5.1  (route groups — blocks everything visual)
 Wave 2:  0.5.2   ‖   0.5.3   ‖   0.5.4a
          DS icon     auth infra   cleanup/renames
          │
+Wave 2.5: 0.5.2.bump  (mid-phase pre-consume bump for Footer's instagram-brand; needs-interactive per AUTONOMOUS_PROTOCOL.md §14c)
+         │
 Wave 3:  0.5.4b  ‖  0.5.4d  ‖  0.5.4e  ‖  0.5.4f  ‖  0.5.5
          NavMenu    LoginBtn    UserInfo    MobileBtn   Footer
          │
@@ -28,7 +30,7 @@ Wave 5:  0.5.6  (verify + phase end-bump + merge to dev)
 - `0.5.4a → 0.5.4b, 0.5.4c, 0.5.4d, 0.5.4e, 0.5.4f` (rename targets must exist)
 - `0.5.3 → 0.5.4c, 0.5.4d` (auth context consumed)
 - `0.5.4b → 0.5.4c` (Header imports retokenized NavMenu)
-- `0.5.2 → 0.5.5` (Footer uses `instagram-brand` icon)
+- `0.5.2 → 0.5.2.bump → 0.5.5` (Footer uses `instagram-brand` icon; mid-phase bump publishes DS so client CI can install the new icon before lane 0.5.5 lands — per `AUTONOMOUS_PROTOCOL.md` §14c)
 - `all → 0.5.6`
 
 ---
@@ -41,6 +43,7 @@ Applied per `AUTONOMOUS_PROTOCOL.md` §4. Drives `autonomous-ready` vs `needs-in
 |---|---|---|---|
 | 0.5.1 | [POLISH][NO-TDD] | `autonomous-ready` | Directory moves + pathname-check drop; scope concrete, no auth logic |
 | 0.5.2 | [MECHANICAL][NO-TDD] | `autonomous-ready` | DS icon additions; isolated to DS repo |
+| 0.5.2.bump | [MECHANICAL][NO-TDD] | `needs-interactive` | Touches publish (`ds-phase-end-bump` skill, mid-phase invocation); hard-denied for autonomous per §9 |
 | 0.5.3 | [REDESIGN][NO-TDD] | `needs-interactive` | Rule 1 fails (REDESIGN); new auth pipeline |
 | 0.5.4a | [MECHANICAL][NO-TDD] | `autonomous-ready` | File ops + import rewrites |
 | 0.5.4b | [POLISH][NO-TDD] | `autonomous-ready` | Pure retokenize; framer drop |
@@ -127,6 +130,50 @@ Applied per `AUTONOMOUS_PROTOCOL.md` §4. Drives `autonomous-ready` vs `needs-in
 - [ ] Registry entries follow existing custom-icon pattern (no divergence)
 - [ ] `pnpm build` passes
 - [ ] `ds-fixes-log.md` has both entries
+
+---
+
+## Lane 0.5.2.bump — Mid-phase DS publish (pre-consume for Footer)
+
+**Repo:** `umichkisa-ds` (+ `KISA-website-client` for repin)
+
+Invoked per `AUTONOMOUS_PROTOCOL.md` §14c. Runs interactively after lane 0.5.2 merges and before lane 0.5.5 runs, so the Footer's `<Icon name="instagram-brand" />` reference resolves against an installed DS version that actually has the icon.
+
+### Files
+
+- Modify: `packages/web/package.json` — bump `version` patch (e.g., `1.0.0 → 1.0.1`)
+- Append: `docs/plans/client-migration/ds-fixes-log.md` — mid-phase bump entry with lane reference
+- Modify (client repo): `KISA-website-client/package.json` — pin `"@umichkisa-ds/web"` to the new version
+- Modify (client repo): `KISA-website-client/package-lock.json` — lockfile sync via `npm install`
+
+### Tasks
+
+- [ ] Confirm lane 0.5.2 is merged to DS `main` and `packages/web/src/components/icon/registry.ts` has both `"instagram"` and `"instagram-brand"` entries
+- [ ] Bump `packages/web/package.json` version → next patch (no minor/major — mid-phase bumps are patch-only)
+- [ ] Append entry to `docs/plans/client-migration/ds-fixes-log.md` marked `mid-phase` with lane reference
+- [ ] Commit DS changes: `chore(web): bump to <version> for phase 0.5 mid-phase pre-consume (lane 0.5.5)`
+- [ ] `git tag web-v<version>`
+- [ ] `git push` + `git push --tags` → GitHub Actions publishes to npm
+- [ ] Wait for the publish workflow to succeed (verify on npm / GitHub Actions)
+- [ ] In `KISA-website-client`: update `package.json` `"@umichkisa-ds/web"` pin to `<version>`
+- [ ] Run `npm install` (no-arg, lockfile sync only) → verify only `@umichkisa-ds/web` entries changed
+- [ ] Commit client on a short-lived branch: `chore(deps): bump @umichkisa-ds/web to <version> (mid-phase pre-consume for lane 0.5.5)`
+- [ ] Open PR against client `dev`; merge once CI is green
+
+### Acceptance criteria
+
+- [ ] DS `packages/web/package.json` version is the new patch
+- [ ] `web-v<version>` tag exists on DS `main` and has been published to npm
+- [ ] `ds-fixes-log.md` has a `mid-phase` entry for this bump
+- [ ] Client `package.json` pins `"@umichkisa-ds/web": "<version>"` (exact, no caret)
+- [ ] Client `package-lock.json` diff is limited to `@umichkisa-ds/web` (and any peer deps it pulled in); no unrelated churn
+- [ ] Any open client PR that consumes the new icon (e.g., lane 0.5.5) turns CI green after rebasing onto the bumped `dev`
+
+### Non-goals
+
+- Minor / major DS version bumps (reserve for phase end)
+- Bundling other DS fixes into this bump (those land at phase end; mid-phase bumps are pre-consume only)
+- Modifying DS component APIs
 
 ---
 

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@umichkisa-ds/web",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "KISA Design System — tokens and components for umichkisa.com",
   "type": "module",
   "main": "./dist/index.cjs",


### PR DESCRIPTION
## Summary
Implements **option 1** from the lane 0.5.5 circularity discussion: add a mid-phase pre-consume bump path to the protocol, schedule it in the Phase 0.5 plan, and execute the bump itself (DS `web` `1.0.0 → 1.0.1`) so lane 0.5.5 (Footer consuming `instagram-brand`) can land with green CI.

## The gap this fixes

- Plan lane 0.5.5 requires `<Icon name="instagram-brand" />`.
- Lane 0.5.2 merged the icon to DS `main`, but the client's lockfile pins `@umichkisa-ds/web@1.0.0` which predates the addition.
- Lane 0.5.6 (`ds-phase-end-bump`) is the only scheduled publish step, but it depends on lane 0.5.5 being merged first — circular.
- `AUTONOMOUS_PROTOCOL.md` §14a (mid-lane fixes) covers adding things to DS; §14b covers phase-end publish. Neither covers mid-phase publish of an already-added addition.

## Changes

### `AUTONOMOUS_PROTOCOL.md`
- **§14c (new)** — "Mid-phase pre-consume bump": structurally identical to §14b, invoked interactively between producing and consuming lanes in the same phase. Patch-only by construction. Includes plan-writing guidance (insert a bump lane after the producing DS lane; `blocked-by` edge from consumer) and omission-recovery behavior (bail the consumer → run bump → relabel `needs-revision`).
- **§19 amendment log** — entry documenting surfacing via lane 0.5.5 PR #59.

### `docs/plans/client-migration/phase-0.5-layout/plan.md`
- Wave diagram: new **Wave 2.5** with `0.5.2.bump` between existing Wave 2 and Wave 3.
- Dependency edges: `0.5.2 → 0.5.2.bump → 0.5.5` (was `0.5.2 → 0.5.5`).
- Label disposition table: `0.5.2.bump` as `[MECHANICAL][NO-TDD]` / `needs-interactive`.
- **New lane section** with explicit Files / Tasks / Acceptance criteria / Non-goals.

### `packages/web/package.json`
- `version`: `1.0.0 → 1.0.1` (patch; mid-phase bumps are patch-only per §14c).

### `docs/plans/client-migration/ds-fixes-log.md`
- Append mid-phase bump entry referencing lane 0.5.5 and protocol §14c.

## Verification
- [x] `pnpm --filter @umichkisa-ds/web typecheck` passes
- [x] `pnpm --filter @umichkisa-ds/web build` passes
- [x] `dist/index.d.ts` exposes `instagram` + `instagram-brand` in `IconName` (verified pre-bump; unchanged by the patch bump itself)

## ⚠️ Deliberately NOT pushed: the `web-v1.0.1` tag

Tag push triggers the GHA publish-to-npm workflow, which is a human-authorized action (external, irreversible state) — autonomous routine avoids it even under explicit approval. After you merge this PR to `main`:

```sh
git checkout main && git pull
git tag web-v1.0.1
git push origin web-v1.0.1
```

Then the follow-up step is on the client side: repin `@umichkisa-ds/web` to `1.0.1` in `KISA-website-client/package.json`, run `npm install`, commit the lockfile to PR #59. I can handle that as a follow-up commit to the lane 0.5.5 branch once the tag is published; ping here or relabel PR #59 `needs-revision` and the next routine run will pick it up.

## Notes

- The bump itself is the same work you'd do in lane 0.5.6; it's just run once per producing-DS-lane instead of once per phase, when the dependency graph demands it. `ds-phase-end-bump` at phase close-out still runs normally for any remaining DS fixes.
- This is also a structural fix for every future phase that adds a DS token/icon/component and consumes it in the same phase — highly likely in Phase 5 (`kisa-web`, ~10+ subphases).
- The existing notes.md update lives on a separate PR (#5) which is unchanged by this one.
