### PR TITLE
Harness + ds-client-constrained-execution improvements (pre-Phase 3)

### DIFF
--- a/.claude/agents/ds-client-review.md
+++ b/.claude/agents/ds-client-review.md
@@ -12,7 +12,10 @@ You are a strict, focused code reviewer. Your only job is to check client app Ty
 
 You will receive:
 1. The full content of one or more changed `.tsx` files from the client app
-2. The full content of `docs/DS_CLIENT_USAGE.md`
+
+## Your reference doc
+
+Before reviewing, Read `docs/DS_CLIENT_USAGE.md` (resolve relative to the umichkisa-ds repo root: `/Users/jiohin/Desktop/KISA/DevTeam/dev/umichkisa-ds/docs/DS_CLIENT_USAGE.md`). This is your authoritative ruleset. Re-read it on every invocation — do not assume cached content.
 
 ## What to scan for
 

--- a/.claude/agents/toss-fe-review.md
+++ b/.claude/agents/toss-fe-review.md
@@ -1,0 +1,98 @@
+---
+name: toss-fe-review
+description: Frontend code-quality reviewer applying Toss Frontend Fundamentals (readability, predictability, cohesion, coupling). Use after ds-client-review passes on a task that touches .tsx files. Returns structured findings with severity gates so the orchestrator can decide whether to re-dispatch the implementer.
+tools: Read, Glob
+---
+
+# Toss FE Code-Quality Reviewer
+
+You are a focused code-quality reviewer applying the Toss Frontend Fundamentals rubric. Your only job is to flag readability / predictability / cohesion / coupling smells in the changed `.tsx` files. Do not check DS constraints (a separate agent owns that). Do not check perf (vercel-react-best-practices owns that at end-of-feature).
+
+## Your input
+
+You will receive the full content of one or more changed `.tsx` files from the client app. The orchestrator may also paste relevant adjacent files for context (parents, siblings, hook callers).
+
+## Rubric — four axes
+
+### Readability — how fast can a new reader understand this code?
+
+- Functions are short and single-purpose. Threshold: a single function or component body > 80 lines is a candidate for extraction; > 120 lines is a clear smell.
+- Conditional logic is named. Inline `condition1 && condition2 || ...` chains buried in JSX should be lifted to a named const (`const canSubmit = ...`).
+- Magic numbers / strings have names. `if (count > 7)` is a smell; `const MAX_ITEMS = 7; if (count > MAX_ITEMS)` is not.
+- Ternaries nest at most 2 deep. `a ? b : c ? d : e` is the limit. `a ? b : (c ? d : (e ? f : g))` is a clear smell.
+- Code reads top-to-bottom. Time-traveling (declaring a hook before its dependencies are defined, or referencing later-declared helpers without `function` hoisting) hurts readability.
+- Mixed concerns in one function (data fetching + transformation + render decisions) should split.
+
+### Predictability — does the code do what its name implies?
+
+- Same-shape functions return same-shape types. If `getUser()` returns `User`, `getOrder()` should return `Order`, not sometimes `null` and sometimes throwing.
+- No name collisions across module / hook / variable scope.
+- A "useFoo" hook returns the canonical shape `{ data, error, isLoading }` (or `{ data, error, isLoading, refetch }`) consistently across hooks in the same feature.
+- No hidden side effects. A function named `formatDate` should not also mutate global state.
+
+### Cohesion — does code that changes together live together?
+
+- Field-level validation logic colocated with the field, not in a top-level form file.
+- Helpers used only by one component live next to that component, not in a shared `utils/` until they're used by ≥ 2 callers.
+- Sub-components that exist only to be passed to one parent live in the parent's file (or a `_shared/` sibling), not a top-level component dir.
+- Cross-field validation logic colocates at the form root with `useFormContext`, not duplicated in each field.
+
+### Coupling — when this changes, what else has to change?
+
+- Components don't reach into siblings' internals. Communicate via props or a shared parent.
+- I/O (Cloudinary calls, fetch, localStorage access) lives in a dedicated `apis/` or hook layer, not inline in components.
+- Type casts (`as Foo`) for `next-auth` session, query params, etc. are centralized in a wrapper hook, not scattered.
+- Deep prop drilling (> 2 levels of `prop` passthrough that the middle layers don't use) is a smell — prefer composition or context.
+
+## Severity gate
+
+Every finding has a severity. The orchestrating skill uses severity to decide what to do.
+
+- **BLOCK** — must be fixed before commit. Re-dispatches the implementer with the finding. Reserved for severe smells:
+  - Function / component body > 80 lines AND mixing concerns (e.g., data + transformation + render in one block)
+  - Ternary depth > 3
+  - Clear duplication (≥ 2 copies of the same 5+ line block in the same file or sibling files)
+  - Leaky abstraction across module boundary (a low-level util reaches into a domain type, or a domain type carries a UI concern)
+  - I/O inline in a component (raw fetch / Cloudinary / localStorage) when the codebase has an established hook/api layer
+- **SUGGEST** — note in PR body, not blocking. Default for most findings: extract a helper, name a magic number, lift a conditional to a named const, colocate a sub-component.
+- **INFO** — purely advisory, no PR-body note. Style preferences, micro-readability nits.
+
+Default disposition is conservative. **When in doubt, downgrade to SUGGEST.** The over-refactor risk (nightly autonomous lanes spinning on Toss-FF re-dispatches) is worse than a missed BLOCK.
+
+Style preferences (one-liner vs. helper for trivial single-call cases, prefer-const-vs-let, arrow-vs-function) are NEVER BLOCK. Often INFO or skipped entirely.
+
+## Output format
+
+For every finding:
+
+```
+FINDING N [BLOCK|SUGGEST|INFO]
+File: <file path>:<line number>
+Axis: readability | predictability | cohesion | coupling
+Smell: <one-line problem statement>
+Suggested refactor: <concrete change or extraction>
+```
+
+End every response with a result line:
+
+```
+---
+Result: B BLOCK, S SUGGEST, I INFO finding(s)
+```
+
+If fully clean:
+
+```
+---
+Result: PASS — no findings
+```
+
+## Rules for reviewing
+
+- Be specific about line numbers
+- Only report Toss-FF rubric smells — not DS constraints (ds-client-review's job), not perf (vercel-react-best-practices' job)
+- Concrete suggestions only — "make this more readable" is not actionable; "extract `validatePochaInfo` to `_shared/validate.ts`" is
+- Do NOT BLOCK on style preferences
+- Do NOT BLOCK on the user's commit habits, naming idioms, or framework choices
+- If the file is < 30 lines and does one thing, default to PASS — short focused code is the goal
+- BLOCK threshold is intentionally narrow: severe smells only

--- a/.claude/skills/ds-client-constrained-execution/SKILL.md
+++ b/.claude/skills/ds-client-constrained-execution/SKILL.md
@@ -162,8 +162,9 @@ After Step 1 of any task that touches `.tsx`, invoke the `ds-client-review` agen
 
 **What to pass in the agent prompt:**
 1. The full content of each changed `.tsx` file (paste inline)
-2. The full content of `docs/DS_CLIENT_USAGE.md` (paste inline)
-3. Instruction: return structured violations per the agent's output format
+2. Instruction: return structured violations per the agent's output format
+
+The agent reads `docs/DS_CLIENT_USAGE.md` itself — do not paste it inline.
 
 **Expected output — violations:**
 ```

--- a/.claude/skills/ds-client-constrained-execution/SKILL.md
+++ b/.claude/skills/ds-client-constrained-execution/SKILL.md
@@ -7,10 +7,10 @@ description: Use when executing a phased client migration plan — each task tha
 
 ## Overview
 
-Drives task-by-task execution of client migration plans. Two modes based on each task's tag:
+Drives task-by-task execution of client migration plans. Two modes based on each task's `[TDD]`/`[NO-TDD]` tag in `plan.md` (not agent discretion — follow the tag):
 
-- **`[NO-TDD]`**: implementer → ds-client-review → typecheck → commit
-- **`[TDD]`**: test-writer (red) → verify fail → implementer (green) → ds-client-review → verify pass → refactor → typecheck → commit
+- **`[NO-TDD]`**: implementer → ds-client-review → toss-fe-review → typecheck → commit
+- **`[TDD]`**: test-writer (red) → verify fail → implementer (green) → ds-client-review → toss-fe-review → verify pass → refactor → typecheck → commit
 
 The main session only orchestrates, reviews, typechecks, and commits. Implementation and test-writing are dispatched to subagents.
 
@@ -18,10 +18,7 @@ The main session only orchestrates, reviews, typechecks, and commits. Implementa
 
 Client migration is **redesign + migration**, not mechanical retokenization. When the original UI conflicts with `DS_CLIENT_USAGE.md`, the executor **must pick the DS-canonical choice**, not preserve the original value.
 
-Examples:
-- Original `md:space-x-8` on a nav strip → DS Component tier is `space-x-4` (16px); ship `space-x-4`, not a mechanical demotion to the nearest-feeling scale value.
-- Original `rounded-lg` on a button → DS buttons use `rounded-md`; ship `rounded-md`.
-- Original `text-gray-600` helper caption under an input → DS uses `text-muted-foreground`; ship the token.
+Examples: `md:space-x-8` nav strip → ship Component-tier `space-x-4`; `rounded-lg` button → ship `rounded-md`; `text-gray-600` helper caption → ship `text-muted-foreground`.
 
 **Visibility rule — `text-muted-foreground` is NOT a default body color.** It is reserved for *genuinely secondary* content: captions, helper text, metadata, placeholder hints, timestamps. Anything the user **needs to read** — card values, list item labels, body paragraphs, form labels, descriptions users actually parse — stays `text-foreground`. Ask: "if this text went to 40% opacity, would the screen still be usable?" If no, it is primary content; keep `text-foreground`. Reflexively mapping every gray → `text-muted-foreground` produces unreadable card content. (Precedent: `feedback_intro_foreground.md` — intro paragraphs are primary content, never muted.)
 
@@ -31,187 +28,123 @@ Only brand identity is preserved unconditionally: navy + maize colors, Korean + 
 
 **This applies at write time, not review time.** The implementer shouldn't ship off-tier values expecting the reviewer to catch them — every spacing, color, radius, and typography value should be tier-justified before the file is written.
 
-## Mode Detection
-
-Read the task's tag from `plan.md`. Every task is marked `[TDD]` or `[NO-TDD]` at audit time. This is not agent discretion — follow the tag.
-
-## Detecting `.tsx` tasks
-
-Look at each task's `**Files:**` section in the plan — not `git status`. A task has `.tsx` changes if any `Create:` or `Modify:` entry ends in `.tsx`.
-
 ## `[NO-TDD]` Execution Loop
+
+Detect `.tsx` changes from the task's `**Files:**` section in the plan (not `git status`) — any `Create:`/`Modify:` entry ending in `.tsx` triggers the review chain.
 
 ```dot
 digraph no_tdd {
-  "Start next task" [shape=box];
-  "Dispatch implementer" [shape=box];
-  "BLOCKED?" [shape=diamond];
-  "HARD STOP (escalate)" [shape=box];
-  "Any .tsx?" [shape=diamond];
-  "ds-client-review" [shape=box];
-  "Violations?" [shape=diamond];
-  "Re-dispatch with violations" [shape=box];
-  "Round 2 exhausted?" [shape=diamond];
-  "HARD STOP (violations)" [shape=box];
-  "Typecheck + commit" [shape=box];
-  "All tasks done?" [shape=diamond];
-  "vercel-react-best-practices" [shape=box];
+  node [shape=box];
+  "BLOCKED?" [shape=diamond]; "Any .tsx?" [shape=diamond]; "DS violations?" [shape=diamond]; "DS r2?" [shape=diamond]; "BLOCK findings?" [shape=diamond]; "Toss r2?" [shape=diamond]; "All done?" [shape=diamond];
 
-  "Start next task" -> "Dispatch implementer";
-  "Dispatch implementer" -> "BLOCKED?";
+  "Start" -> "Dispatch implementer" -> "BLOCKED?";
   "BLOCKED?" -> "HARD STOP (escalate)" [label="yes"];
-  "BLOCKED?" -> "Any .tsx?" [label="no (DONE)"];
+  "BLOCKED?" -> "Any .tsx?" [label="no"];
   "Any .tsx?" -> "ds-client-review" [label="yes"];
   "Any .tsx?" -> "Typecheck + commit" [label="no"];
-  "ds-client-review" -> "Violations?";
-  "Violations?" -> "Typecheck + commit" [label="no (PASS)"];
-  "Violations?" -> "Re-dispatch with violations" [label="yes"];
-  "Re-dispatch with violations" -> "Round 2 exhausted?";
-  "Round 2 exhausted?" -> "HARD STOP (violations)" [label="still failing"];
-  "Round 2 exhausted?" -> "ds-client-review" [label="no, re-check"];
-  "Typecheck + commit" -> "All tasks done?";
-  "All tasks done?" -> "vercel-react-best-practices" [label="yes"];
-  "All tasks done?" -> "Start next task" [label="no"];
+  "ds-client-review" -> "DS violations?";
+  "DS violations?" -> "toss-fe-review" [label="no (PASS)"];
+  "DS violations?" -> "Re-dispatch (DS)" [label="yes"];
+  "Re-dispatch (DS)" -> "DS r2?";
+  "DS r2?" -> "HARD STOP (DS violations)" [label="exhausted"];
+  "DS r2?" -> "ds-client-review" [label="re-check"];
+  "toss-fe-review" -> "BLOCK findings?";
+  "BLOCK findings?" -> "Collect SUGGEST/INFO" [label="no"];
+  "BLOCK findings?" -> "Re-dispatch (toss)" [label="yes"];
+  "Re-dispatch (toss)" -> "Toss r2?";
+  "Toss r2?" -> "HARD STOP (toss BLOCK)" [label="exhausted"];
+  "Toss r2?" -> "toss-fe-review" [label="re-check"];
+  "Collect SUGGEST/INFO" -> "Typecheck + commit" -> "All done?";
+  "All done?" -> "vercel-react-best-practices" [label="yes"];
+  "All done?" -> "Start" [label="no"];
 }
 ```
 
 ## `[TDD]` Execution Loop
 
+Same review chain, sandwiched between RED and GREEN test phases.
+
 ```dot
 digraph tdd {
-  "Start next task" [shape=box];
-  "Dispatch test-writer" [shape=box];
-  "Test-writer BLOCKED?" [shape=diamond];
-  "HARD STOP (escalate)" [shape=box];
-  "Run tests (expect RED)" [shape=box];
-  "Tests fail?" [shape=diamond];
-  "Re-dispatch test-writer" [shape=box];
-  "Dispatch implementer" [shape=box];
-  "Implementer BLOCKED?" [shape=diamond];
-  "HARD STOP (impl escalate)" [shape=box];
-  "Any .tsx?" [shape=diamond];
-  "ds-client-review" [shape=box];
-  "Violations?" [shape=diamond];
-  "Re-dispatch impl with violations" [shape=box];
-  "Round 2 exhausted?" [shape=diamond];
-  "HARD STOP (violations)" [shape=box];
-  "Run tests (expect GREEN)" [shape=box];
-  "Tests pass?" [shape=diamond];
-  "Re-dispatch implementer (fix)" [shape=box];
-  "Refactor (optional)" [shape=box];
-  "Tests still green?" [shape=diamond];
-  "Typecheck + commit" [shape=box];
-  "All tasks done?" [shape=diamond];
-  "vercel-react-best-practices" [shape=box];
+  node [shape=box];
+  "TW BLOCKED?" [shape=diamond]; "Tests RED?" [shape=diamond]; "Impl BLOCKED?" [shape=diamond]; "Any .tsx?" [shape=diamond]; "DS violations?" [shape=diamond]; "DS r2?" [shape=diamond]; "BLOCK findings?" [shape=diamond]; "Toss r2?" [shape=diamond]; "Tests GREEN?" [shape=diamond]; "Still green?" [shape=diamond]; "All done?" [shape=diamond];
 
-  "Start next task" -> "Dispatch test-writer";
-  "Dispatch test-writer" -> "Test-writer BLOCKED?";
-  "Test-writer BLOCKED?" -> "HARD STOP (escalate)" [label="yes"];
-  "Test-writer BLOCKED?" -> "Run tests (expect RED)" [label="no (DONE)"];
-  "Run tests (expect RED)" -> "Tests fail?";
-  "Tests fail?" -> "Dispatch implementer" [label="yes (correct RED)"];
-  "Tests fail?" -> "Re-dispatch test-writer" [label="no (tests pass = wrong tests)"];
-  "Re-dispatch test-writer" -> "Run tests (expect RED)";
-  "Dispatch implementer" -> "Implementer BLOCKED?";
-  "Implementer BLOCKED?" -> "HARD STOP (impl escalate)" [label="yes"];
-  "Implementer BLOCKED?" -> "Any .tsx?" [label="no (DONE)"];
+  "Start" -> "Dispatch test-writer" -> "TW BLOCKED?";
+  "TW BLOCKED?" -> "HARD STOP (TW)" [label="yes"];
+  "TW BLOCKED?" -> "Run tests (RED)" [label="no"];
+  "Run tests (RED)" -> "Tests RED?";
+  "Tests RED?" -> "Dispatch implementer" [label="yes"];
+  "Tests RED?" -> "Re-dispatch TW" [label="no (wrong tests)"];
+  "Re-dispatch TW" -> "Run tests (RED)";
+  "Dispatch implementer" -> "Impl BLOCKED?";
+  "Impl BLOCKED?" -> "HARD STOP (impl)" [label="yes"];
+  "Impl BLOCKED?" -> "Any .tsx?" [label="no"];
   "Any .tsx?" -> "ds-client-review" [label="yes"];
-  "Any .tsx?" -> "Run tests (expect GREEN)" [label="no"];
-  "ds-client-review" -> "Violations?";
-  "Violations?" -> "Run tests (expect GREEN)" [label="no (PASS)"];
-  "Violations?" -> "Re-dispatch impl with violations" [label="yes"];
-  "Re-dispatch impl with violations" -> "Round 2 exhausted?";
-  "Round 2 exhausted?" -> "HARD STOP (violations)" [label="still failing"];
-  "Round 2 exhausted?" -> "ds-client-review" [label="no, re-check"];
-  "Run tests (expect GREEN)" -> "Tests pass?";
-  "Tests pass?" -> "Refactor (optional)" [label="yes"];
-  "Tests pass?" -> "Re-dispatch implementer (fix)" [label="no"];
-  "Re-dispatch implementer (fix)" -> "Run tests (expect GREEN)";
-  "Refactor (optional)" -> "Tests still green?";
-  "Tests still green?" -> "Typecheck + commit" [label="yes"];
-  "Tests still green?" -> "Refactor (optional)" [label="no (revert)"];
-  "Typecheck + commit" -> "All tasks done?";
-  "All tasks done?" -> "vercel-react-best-practices" [label="yes"];
-  "All tasks done?" -> "Start next task" [label="no"];
+  "Any .tsx?" -> "Run tests (GREEN)" [label="no"];
+  "ds-client-review" -> "DS violations?";
+  "DS violations?" -> "toss-fe-review" [label="no (PASS)"];
+  "DS violations?" -> "Re-dispatch (DS)" [label="yes"];
+  "Re-dispatch (DS)" -> "DS r2?";
+  "DS r2?" -> "HARD STOP (DS)" [label="exhausted"];
+  "DS r2?" -> "ds-client-review" [label="re-check"];
+  "toss-fe-review" -> "BLOCK findings?";
+  "BLOCK findings?" -> "Collect SUGGEST/INFO" [label="no"];
+  "BLOCK findings?" -> "Re-dispatch (toss)" [label="yes"];
+  "Re-dispatch (toss)" -> "Toss r2?";
+  "Toss r2?" -> "HARD STOP (toss)" [label="exhausted"];
+  "Toss r2?" -> "toss-fe-review" [label="re-check"];
+  "Collect SUGGEST/INFO" -> "Run tests (GREEN)" -> "Tests GREEN?";
+  "Tests GREEN?" -> "Refactor" [label="yes"];
+  "Tests GREEN?" -> "Re-dispatch impl (fix)" [label="no"];
+  "Re-dispatch impl (fix)" -> "Run tests (GREEN)";
+  "Refactor" -> "Still green?";
+  "Still green?" -> "Typecheck + commit" [label="yes"];
+  "Still green?" -> "Refactor" [label="no (revert)"];
+  "Typecheck + commit" -> "All done?";
+  "All done?" -> "vercel-react-best-practices" [label="yes"];
+  "All done?" -> "Start" [label="no"];
 }
 ```
 
-## Implementer Subagent
+## Subagent Templates
 
-Use the template in `implementer-template.md` (same directory as this skill). Key rules:
-- Paste the **full task text** from the plan inline — do not make the subagent read the plan file
-- Read `docs/DS_CLIENT_USAGE.md` and paste its full contents into the placeholder
-- The implementer does **Step 1 only** (implement all files for the task) — never typecheck or commit
-- In `[TDD]` mode: the implementer writes **minimal code to pass the tests** — nothing more
-- For revisions: include the full ds-client-review violation report in the prompt
-- If implementer returns BLOCKED or NEEDS_CONTEXT → hard stop, surface to user
-- Record **Deviations from original** in PR body — every value changed from the source (not just renamed) needs a one-line DS justification (e.g. "gap-8 → gap-4: nav items = Component tier per DS_CONSTRAINTS.md:129")
-
-## Test-Writer Subagent (`[TDD]` mode only)
-
-Use the template in `test-writer-template.md` (same directory as this skill). Key rules:
-- Paste the **full task text** from the plan inline
-- The test-writer writes **failing tests only** — zero production code
-- Tests must fail because the feature is missing, not because of typos or import errors
-- After dispatch, run the tests yourself and verify they fail (RED phase)
-- If tests pass immediately → the tests are wrong. Re-dispatch the test-writer.
+Use `implementer-template.md` and `test-writer-template.md` (same directory). Critical rules:
+- Paste the **full task text** from the plan inline — do NOT make the subagent read the plan file
+- Implementer does Step 1 only (write files); test-writer writes failing tests only (zero production code)
 
 ## DS Client Review
 
-After Step 1 of any task that touches `.tsx`, invoke the `ds-client-review` agent using the Agent tool.
+After Step 1 of any task that touches `.tsx`, invoke the `ds-client-review` agent. Pass: each changed `.tsx` file inline + instruction to return structured violations. The agent reads `docs/DS_CLIENT_USAGE.md` itself — do not paste it inline.
 
-**What to pass in the agent prompt:**
-1. The full content of each changed `.tsx` file (paste inline)
-2. Instruction: return structured violations per the agent's output format
+Output: structured `VIOLATION N / File / Rule / Violation / Fix` blocks ending with `Result: N violation(s)...`, or `Result: PASS — no violations found` on clean.
 
-The agent reads `docs/DS_CLIENT_USAGE.md` itself — do not paste it inline.
+**Hard stop on violations after 2 rounds:** print `DS CLIENT REVIEW HARD STOP — unresolved violations after 2 rounds`, list every remaining violation (file:line + quoted rule + fix), stop, and ask:
+> (a) Clarify/relax the constraint in DS_CLIENT_USAGE.md (b) Adjust the spec/approach (c) One more round with new direction (d) DS bug — invoke `ds-fix-during-migration`, then resume
 
-**Expected output — violations:**
-```
-VIOLATION 1
-File: src/features/jobs/JobCard.tsx:12
-Rule: "Never: Import from `react-icons` — fully replaced by the DS icon system."
-Violation: `import { FiBriefcase } from 'react-icons/fi'` imports from react-icons.
-Fix: Replace with `<Icon name="briefcase" />` from `@umichkisa-ds/web`.
+Wait for explicit instruction.
 
----
-Result: 1 violation(s), 0 warning(s) found
-```
+## Toss FE Review
 
-**Expected output — clean pass:**
-```
----
-Result: PASS — no violations found
-```
+After ds-client-review passes (no violations), and before typecheck (NO-TDD) or tests-green-verify (TDD), invoke the `toss-fe-review` agent. Pass: each changed `.tsx` file inline, optionally adjacent files for context (parents, hook callers, siblings) when referenced non-trivially, and instruction to return structured findings. The agent reads its own rubric — do not paste rules inline.
 
-## Hard Stop
+**Severity gate (orchestrator behavior):**
+- **BLOCK** finding(s) → re-dispatch implementer with the findings; same 2-round hard-stop rule as ds-client-review
+- **SUGGEST** / **INFO** → collect for the PR body's `## Toss FE notes` section; do NOT re-dispatch
 
-When violations remain after 2 revision rounds:
+**Hard stop on toss BLOCK after 2 rounds:** print `TOSS FE REVIEW HARD STOP — unresolved BLOCK findings after 2 rounds`, list remaining BLOCKs, stop, and ask:
+> (a) Downgrade BLOCK → SUGGEST and move on (b) Adjust task scope — break refactor into its own lane (c) One more round with new direction (d) Override — accept and ship
 
-1. Print: `DS CLIENT REVIEW HARD STOP — unresolved violations after 2 rounds`
-2. List every remaining violation with file:line, exact quoted rule, and suggested fix
-3. Stop. Do not move to the next task.
-4. Ask:
-   > How would you like to proceed?
-   > (a) Clarify or relax the constraint in DS_CLIENT_USAGE.md
-   > (b) Adjust the spec / approach for this task
-   > (c) Attempt one more round with new direction from you
-   > (d) This is a DS bug — invoke `ds-fix-during-migration` to fix the DS first, then resume
+Wait for explicit instruction.
 
-Wait for explicit instruction before continuing.
+**SUGGEST / INFO collection:** Append SUGGEST findings to a `## Toss FE notes` section in the PR body under each lane's commit. INFO findings are not surfaced.
 
 ## Final Review
 
-After all tasks pass DS client review, invoke the `vercel-react-best-practices` skill for a final code quality pass. Then proceed to the plan's session-end checklist.
+After all tasks pass both review gates, invoke the `vercel-react-best-practices` skill for a final code quality pass. Then proceed to the plan's session-end checklist.
 
 ## Common Mistakes
 
-- **Using git status to detect .tsx changes** — always use the task's `Files:` section instead
-- **Running typecheck before DS client review** — DS client review must pass first; typecheck comes after
-- **Skipping review on mixed tasks** — if a task touches both `.md` and `.tsx`, the `.tsx` always triggers the review cycle
-- **Batching tasks** — review each task independently; do not accumulate changes across tasks before reviewing
-- **Treating round 2 as soft** — after round 2 with violations still present, hard stop is mandatory, not optional
-- **Summarizing violations** — always quote the exact rule text from DS_CLIENT_USAGE.md, never paraphrase
-- **Wrong mode** — follow the task's `[TDD]`/`[NO-TDD]` tag exactly. Do not switch modes based on task complexity or your judgment
-- **Skipping RED verification in TDD mode** — you MUST run the tests yourself and see them fail before dispatching the implementer. No exceptions.
-- **Implementer writing tests in TDD mode** — the implementer writes production code only. Tests come from the test-writer subagent.
+- **Using git status to detect .tsx changes** — always use the task's `Files:` section
+- **Wrong mode** — follow the task's `[TDD]`/`[NO-TDD]` tag exactly; never switch based on judgment
+- **Skipping RED verification in TDD mode** — run tests yourself and see them fail before dispatching the implementer
+- **Summarizing violations** — quote the exact rule text from DS_CLIENT_USAGE.md, never paraphrase

--- a/.claude/skills/ds-client-constrained-execution/implementer-template.md
+++ b/.claude/skills/ds-client-constrained-execution/implementer-template.md
@@ -17,6 +17,32 @@ Agent tool (general-purpose):
 
     [PASTE FULL TASK TEXT FROM PLAN HERE — do not make the subagent read the file]
 
+    ## Pre-flight (do this FIRST — before writing any code)
+
+    Read `docs/DS_CLIENT_USAGE.md` Part 1 (Write-Time Decision Tree). Then,
+    for the task you're about to implement, list every styling decision
+    you'll make and its DS tier or token justification:
+
+    1. Spacing values — list every `gap-*`, `space-*`, `p*`, `m*` you'll write,
+       with the role of its container (Element / Component / Section / inline)
+       and the canonical tier value.
+    2. Color values — list every `text-*`, `bg-*`, `border-*` and which DS
+       semantic token applies (`text-foreground` vs `text-muted-foreground`,
+       `bg-surface` vs `bg-brand-accent-subtle`, etc.).
+    3. Radius values — list every `rounded-*` and the DS surface role.
+    4. Type values — list every `type-*` class with its color pairing.
+    5. Icon names + sizes — list every `<Icon name="..." size="...">` you'll
+       write. If a name is missing from the registry, flag it as a DS gap.
+
+    If you cannot tier-justify a value, do NOT write it — flag it as a
+    question in your report and stop. The reviewer will not catch every
+    off-tier value; you must catch them at write time.
+
+    This is the "redesign over preserve" principle: when the original
+    code's value conflicts with the DS tier, ship the DS-canonical value,
+    not a mechanical demotion. Record every such choice as a "Deviation
+    from original" line for the PR body.
+
     ## Your Job
 
     Implement **Step 1 only** — create or modify the files as specified. Do NOT run typecheck
@@ -31,8 +57,12 @@ Agent tool (general-purpose):
 
     ## DS Client Usage Constraints
 
-    Follow every rule below as you write code. A constraint review agent will verify your
-    output — aim for zero violations on the first pass.
+    Follow every rule in `docs/DS_CLIENT_USAGE.md`. A constraint review agent
+    will verify your output — aim for zero violations on the first pass.
+
+    Read the full file before writing. Part 1 (Write-Time Decision Tree)
+    is your primary guide; Part 2 (Review-Time Rulebook) is what the
+    reviewer will check you against.
 
     [PASTE FULL CONTENTS OF docs/DS_CLIENT_USAGE.md HERE]
 

--- a/.claude/skills/playwright-cli/SKILL.md
+++ b/.claude/skills/playwright-cli/SKILL.md
@@ -1,0 +1,386 @@
+---
+name: playwright-cli
+description: Automate browser interactions, test web pages and work with Playwright tests.
+allowed-tools: Bash(playwright-cli:*) Bash(npx:*) Bash(npm:*)
+---
+
+# Browser Automation with playwright-cli
+
+## Quick start
+
+```bash
+# open new browser
+playwright-cli open
+# navigate to a page
+playwright-cli goto https://playwright.dev
+# interact with the page using refs from the snapshot
+playwright-cli click e15
+playwright-cli type "page.click"
+playwright-cli press Enter
+# take a screenshot (rarely used, as snapshot is more common)
+playwright-cli screenshot
+# close the browser
+playwright-cli close
+```
+
+## Commands
+
+### Core
+
+```bash
+playwright-cli open
+# open and navigate right away
+playwright-cli open https://example.com/
+playwright-cli goto https://playwright.dev
+playwright-cli type "search query"
+playwright-cli click e3
+playwright-cli dblclick e7
+# --submit presses Enter after filling the element
+playwright-cli fill e5 "user@example.com"  --submit
+playwright-cli drag e2 e8
+# drop files or data onto an element (from outside the page)
+playwright-cli drop e4 --path=./image.png
+playwright-cli drop e4 --data="text/plain=hello world"
+playwright-cli hover e4
+playwright-cli select e9 "option-value"
+playwright-cli upload ./document.pdf
+playwright-cli check e12
+playwright-cli uncheck e12
+playwright-cli snapshot
+playwright-cli eval "document.title"
+playwright-cli eval "el => el.textContent" e5
+# get element id, class, or any attribute not visible in the snapshot
+playwright-cli eval "el => el.id" e5
+playwright-cli eval "el => el.getAttribute('data-testid')" e5
+playwright-cli dialog-accept
+playwright-cli dialog-accept "confirmation text"
+playwright-cli dialog-dismiss
+playwright-cli resize 1920 1080
+playwright-cli close
+```
+
+### Navigation
+
+```bash
+playwright-cli go-back
+playwright-cli go-forward
+playwright-cli reload
+```
+
+### Keyboard
+
+```bash
+playwright-cli press Enter
+playwright-cli press ArrowDown
+playwright-cli keydown Shift
+playwright-cli keyup Shift
+```
+
+### Mouse
+
+```bash
+playwright-cli mousemove 150 300
+playwright-cli mousedown
+playwright-cli mousedown right
+playwright-cli mouseup
+playwright-cli mouseup right
+playwright-cli mousewheel 0 100
+```
+
+### Save as
+
+```bash
+playwright-cli screenshot
+playwright-cli screenshot e5
+playwright-cli screenshot --filename=page.png
+playwright-cli pdf --filename=page.pdf
+```
+
+### Tabs
+
+```bash
+playwright-cli tab-list
+playwright-cli tab-new
+playwright-cli tab-new https://example.com/page
+playwright-cli tab-close
+playwright-cli tab-close 2
+playwright-cli tab-select 0
+```
+
+### Storage
+
+```bash
+playwright-cli state-save
+playwright-cli state-save auth.json
+playwright-cli state-load auth.json
+
+# Cookies
+playwright-cli cookie-list
+playwright-cli cookie-list --domain=example.com
+playwright-cli cookie-get session_id
+playwright-cli cookie-set session_id abc123
+playwright-cli cookie-set session_id abc123 --domain=example.com --httpOnly --secure
+playwright-cli cookie-delete session_id
+playwright-cli cookie-clear
+
+# LocalStorage
+playwright-cli localstorage-list
+playwright-cli localstorage-get theme
+playwright-cli localstorage-set theme dark
+playwright-cli localstorage-delete theme
+playwright-cli localstorage-clear
+
+# SessionStorage
+playwright-cli sessionstorage-list
+playwright-cli sessionstorage-get step
+playwright-cli sessionstorage-set step 3
+playwright-cli sessionstorage-delete step
+playwright-cli sessionstorage-clear
+```
+
+### Network
+
+```bash
+playwright-cli route "**/*.jpg" --status=404
+playwright-cli route "https://api.example.com/**" --body='{"mock": true}'
+playwright-cli route-list
+playwright-cli unroute "**/*.jpg"
+playwright-cli unroute
+```
+
+### DevTools
+
+```bash
+playwright-cli console
+playwright-cli console warning
+playwright-cli network
+playwright-cli run-code "async page => await page.context().grantPermissions(['geolocation'])"
+playwright-cli run-code --filename=script.js
+playwright-cli tracing-start
+playwright-cli tracing-stop
+playwright-cli video-start video.webm
+playwright-cli video-chapter "Chapter Title" --description="Details" --duration=2000
+playwright-cli video-stop
+
+# launch the dashboard with annotation prompt to ask the user for input
+playwright-cli show --annotate
+
+# generate a Playwright locator for an element from its ref or selector
+playwright-cli generate-locator e5 --raw
+
+# show a persistent highlight overlay for an element, optionally with a custom style
+playwright-cli highlight e5
+playwright-cli highlight e5 --style="outline: 3px dashed red"
+# hide a single element highlight, or all page highlights when no target is given
+playwright-cli highlight e5 --hide
+playwright-cli highlight --hide
+```
+
+## Raw output
+
+The global `--raw` option strips page status, generated code, and snapshot sections from the output, returning only the result value. Use it to pipe command output into other tools. Commands that don't produce output return nothing.
+
+```bash
+playwright-cli --raw eval "JSON.stringify(performance.timing)" | jq '.loadEventEnd - .navigationStart'
+playwright-cli --raw eval "JSON.stringify([...document.querySelectorAll('a')].map(a => a.href))" > links.json
+playwright-cli --raw snapshot > before.yml
+playwright-cli click e5
+playwright-cli --raw snapshot > after.yml
+diff before.yml after.yml
+TOKEN=$(playwright-cli --raw cookie-get session_id)
+playwright-cli --raw localstorage-get theme
+```
+
+For structured output wrapping every reply as JSON, pass --json
+```bash
+playwright-cli list --json
+```
+
+## Open parameters
+```bash
+# Use specific browser when creating session
+playwright-cli open --browser=chrome
+playwright-cli open --browser=firefox
+playwright-cli open --browser=webkit
+playwright-cli open --browser=msedge
+
+# Use persistent profile (by default profile is in-memory)
+playwright-cli open --persistent
+# Use persistent profile with custom directory
+playwright-cli open --profile=/path/to/profile
+
+# Connect to browser via Playwright Extension
+playwright-cli attach --extension=chrome
+
+# Connect to a running Chrome or Edge by channel name
+playwright-cli attach --cdp=chrome
+playwright-cli attach --cdp=msedge
+
+# Connect to a running browser via CDP endpoint
+playwright-cli attach --cdp=http://localhost:9222
+
+# Start with config file
+playwright-cli open --config=my-config.json
+
+# Close the browser
+playwright-cli close
+# Detach from an attached browser (leaves the external browser running)
+playwright-cli -s=msedge detach
+# Delete user data for the default session
+playwright-cli delete-data
+```
+
+## Snapshots
+
+After each command, playwright-cli provides a snapshot of the current browser state.
+
+```bash
+> playwright-cli goto https://example.com
+### Page
+- Page URL: https://example.com/
+- Page Title: Example Domain
+### Snapshot
+[Snapshot](.playwright-cli/page-2026-02-14T19-22-42-679Z.yml)
+```
+
+You can also take a snapshot on demand using `playwright-cli snapshot` command. All the options below can be combined as needed.
+
+```bash
+# default - save to a file with timestamp-based name
+playwright-cli snapshot
+
+# save to file, use when snapshot is a part of the workflow result
+playwright-cli snapshot --filename=after-click.yaml
+
+# snapshot an element instead of the whole page
+playwright-cli snapshot "#main"
+
+# limit snapshot depth for efficiency, take a partial snapshot afterwards
+playwright-cli snapshot --depth=4
+playwright-cli snapshot e34
+
+# include each element's bounding box as [box=x,y,width,height]
+playwright-cli snapshot --boxes
+```
+
+## Targeting elements
+
+By default, use refs from the snapshot to interact with page elements.
+
+```bash
+# get snapshot with refs
+playwright-cli snapshot
+
+# interact using a ref
+playwright-cli click e15
+```
+
+You can also use css selectors or Playwright locators.
+
+```bash
+# css selector
+playwright-cli click "#main > button.submit"
+
+# role locator
+playwright-cli click "getByRole('button', { name: 'Submit' })"
+
+# test id
+playwright-cli click "getByTestId('submit-button')"
+```
+
+## Browser Sessions
+
+```bash
+# create new browser session named "mysession" with persistent profile
+playwright-cli -s=mysession open example.com --persistent
+# same with manually specified profile directory (use when requested explicitly)
+playwright-cli -s=mysession open example.com --profile=/path/to/profile
+playwright-cli -s=mysession click e6
+playwright-cli -s=mysession close  # stop a named browser
+playwright-cli -s=mysession delete-data  # delete user data for persistent session
+
+playwright-cli list
+# Close all browsers
+playwright-cli close-all
+# Forcefully kill all browser processes
+playwright-cli kill-all
+```
+
+## Installation
+
+If global `playwright-cli` command is not available, try a local version via `npx playwright-cli`:
+
+```bash
+npx --no-install playwright-cli --version
+```
+
+When local version is available, use `npx playwright-cli` in all commands. Otherwise, install `playwright-cli` as a global command:
+
+```bash
+npm install -g @playwright/cli@latest
+```
+
+## Example: Form submission
+
+```bash
+playwright-cli open https://example.com/form
+playwright-cli snapshot
+
+playwright-cli fill e1 "user@example.com"
+playwright-cli fill e2 "password123"
+playwright-cli click e3
+playwright-cli snapshot
+playwright-cli close
+```
+
+## Example: Multi-tab workflow
+
+```bash
+playwright-cli open https://example.com
+playwright-cli tab-new https://example.com/other
+playwright-cli tab-list
+playwright-cli tab-select 0
+playwright-cli snapshot
+playwright-cli close
+```
+
+## Example: Debugging with DevTools
+
+```bash
+playwright-cli open https://example.com
+playwright-cli click e4
+playwright-cli fill e7 "test"
+playwright-cli console
+playwright-cli network
+playwright-cli close
+```
+
+```bash
+playwright-cli open https://example.com
+playwright-cli tracing-start
+playwright-cli click e4
+playwright-cli fill e7 "test"
+playwright-cli tracing-stop
+playwright-cli close
+```
+
+## Example: Interactive session
+
+Ask the user to annotate the UI. User can provide contextual tasks or ask contextual questions using annotations:
+
+```bash
+playwright-cli open https://example.com
+playwright-cli show --annotate
+```
+
+## Specific tasks
+
+* **Running and Debugging Playwright tests** [references/playwright-tests.md](references/playwright-tests.md)
+* **Request mocking** [references/request-mocking.md](references/request-mocking.md)
+* **Running Playwright code** [references/running-code.md](references/running-code.md)
+* **Browser session management** [references/session-management.md](references/session-management.md)
+* **Storage state (cookies, localStorage)** [references/storage-state.md](references/storage-state.md)
+* **Test generation** [references/test-generation.md](references/test-generation.md)
+* **Tracing** [references/tracing.md](references/tracing.md)
+* **Video recording** [references/video-recording.md](references/video-recording.md)
+* **Inspecting element attributes** [references/element-attributes.md](references/element-attributes.md)

--- a/.claude/skills/playwright-cli/references/element-attributes.md
+++ b/.claude/skills/playwright-cli/references/element-attributes.md
@@ -1,0 +1,23 @@
+# Inspecting Element Attributes
+
+When the snapshot doesn't show an element's `id`, `class`, `data-*` attributes, or other DOM properties, use `eval` to inspect them.
+
+## Examples
+
+```bash
+playwright-cli snapshot
+# snapshot shows a button as e7 but doesn't reveal its id or data attributes
+
+# get the element's id
+playwright-cli eval "el => el.id" e7
+
+# get all CSS classes
+playwright-cli eval "el => el.className" e7
+
+# get a specific attribute
+playwright-cli eval "el => el.getAttribute('data-testid')" e7
+playwright-cli eval "el => el.getAttribute('aria-label')" e7
+
+# get a computed style property
+playwright-cli eval "el => getComputedStyle(el).display" e7
+```

--- a/.claude/skills/playwright-cli/references/playwright-tests.md
+++ b/.claude/skills/playwright-cli/references/playwright-tests.md
@@ -1,0 +1,39 @@
+# Running Playwright Tests
+
+To run Playwright tests, use the `npx playwright test` command, or a package manager script. To avoid opening the interactive html report, use `PLAYWRIGHT_HTML_OPEN=never` environment variable.
+
+```bash
+# Run all tests
+PLAYWRIGHT_HTML_OPEN=never npx playwright test
+
+# Run all tests through a custom npm script
+PLAYWRIGHT_HTML_OPEN=never npm run special-test-command
+```
+
+# Debugging Playwright Tests
+
+To debug a failing Playwright test, run it with `--debug=cli` option. This command will pause the test at the start and print the debugging instructions.
+
+**IMPORTANT**: run the command in the background and check the output until "Debugging Instructions" is printed.
+
+Once instructions containing a session name are printed, use `playwright-cli` to attach the session and explore the page.
+
+```bash
+# Run the test
+PLAYWRIGHT_HTML_OPEN=never npx playwright test --debug=cli
+# ...
+# ... debugging instructions for "tw-abcdef" session ...
+# ...
+
+# Attach to the test
+playwright-cli attach tw-abcdef
+```
+
+Keep the test running in the background while you explore and look for a fix.
+The test is paused at the start, so you should step over or pause at a particular location
+where the problem is most likely to be.
+
+Every action you perform with `playwright-cli` generates corresponding Playwright TypeScript code.
+This code appears in the output and can be copied directly into the test. Most of the time, a specific locator or an expectation should be updated, but it could also be a bug in the app. Use your judgement.
+
+After fixing the test, stop the background test run. Rerun to check that test passes.

--- a/.claude/skills/playwright-cli/references/request-mocking.md
+++ b/.claude/skills/playwright-cli/references/request-mocking.md
@@ -1,0 +1,87 @@
+# Request Mocking
+
+Intercept, mock, modify, and block network requests.
+
+## CLI Route Commands
+
+```bash
+# Mock with custom status
+playwright-cli route "**/*.jpg" --status=404
+
+# Mock with JSON body
+playwright-cli route "**/api/users" --body='[{"id":1,"name":"Alice"}]' --content-type=application/json
+
+# Mock with custom headers
+playwright-cli route "**/api/data" --body='{"ok":true}' --header="X-Custom: value"
+
+# Remove headers from requests
+playwright-cli route "**/*" --remove-header=cookie,authorization
+
+# List active routes
+playwright-cli route-list
+
+# Remove a route or all routes
+playwright-cli unroute "**/*.jpg"
+playwright-cli unroute
+```
+
+## URL Patterns
+
+```
+**/api/users           - Exact path match
+**/api/*/details       - Wildcard in path
+**/*.{png,jpg,jpeg}    - Match file extensions
+**/search?q=*          - Match query parameters
+```
+
+## Advanced Mocking with run-code
+
+For conditional responses, request body inspection, response modification, or delays:
+
+### Conditional Response Based on Request
+
+```bash
+playwright-cli run-code "async page => {
+  await page.route('**/api/login', route => {
+    const body = route.request().postDataJSON();
+    if (body.username === 'admin') {
+      route.fulfill({ body: JSON.stringify({ token: 'mock-token' }) });
+    } else {
+      route.fulfill({ status: 401, body: JSON.stringify({ error: 'Invalid' }) });
+    }
+  });
+}"
+```
+
+### Modify Real Response
+
+```bash
+playwright-cli run-code "async page => {
+  await page.route('**/api/user', async route => {
+    const response = await route.fetch();
+    const json = await response.json();
+    json.isPremium = true;
+    await route.fulfill({ response, json });
+  });
+}"
+```
+
+### Simulate Network Failures
+
+```bash
+playwright-cli run-code "async page => {
+  await page.route('**/api/offline', route => route.abort('internetdisconnected'));
+}"
+# Options: connectionrefused, timedout, connectionreset, internetdisconnected
+```
+
+### Delayed Response
+
+```bash
+playwright-cli run-code "async page => {
+  await page.route('**/api/slow', async route => {
+    await new Promise(r => setTimeout(r, 3000));
+    route.fulfill({ body: JSON.stringify({ data: 'loaded' }) });
+  });
+}"
+```

--- a/.claude/skills/playwright-cli/references/running-code.md
+++ b/.claude/skills/playwright-cli/references/running-code.md
@@ -1,0 +1,241 @@
+# Running Custom Playwright Code
+
+Use `run-code` to execute arbitrary Playwright code for advanced scenarios not covered by CLI commands.
+
+## Syntax
+
+```bash
+playwright-cli run-code "async page => {
+  // Your Playwright code here
+  // Access page.context() for browser context operations
+}"
+```
+
+You can also load the function from a file:
+
+```bash
+playwright-cli run-code --filename=./my-script.js
+```
+
+
+The code must be a single function expression, it is wrapped in `(...)` and evaluated.
+import/export/require syntax is not supported.
+
+## Geolocation
+
+```bash
+# Grant geolocation permission and set location
+playwright-cli run-code "async page => {
+  await page.context().grantPermissions(['geolocation']);
+  await page.context().setGeolocation({ latitude: 37.7749, longitude: -122.4194 });
+}"
+
+# Set location to London
+playwright-cli run-code "async page => {
+  await page.context().grantPermissions(['geolocation']);
+  await page.context().setGeolocation({ latitude: 51.5074, longitude: -0.1278 });
+}"
+
+# Clear geolocation override
+playwright-cli run-code "async page => {
+  await page.context().clearPermissions();
+}"
+```
+
+## Permissions
+
+```bash
+# Grant multiple permissions
+playwright-cli run-code "async page => {
+  await page.context().grantPermissions([
+    'geolocation',
+    'notifications',
+    'camera',
+    'microphone'
+  ]);
+}"
+
+# Grant permissions for specific origin
+playwright-cli run-code "async page => {
+  await page.context().grantPermissions(['clipboard-read'], {
+    origin: 'https://example.com'
+  });
+}"
+```
+
+## Media Emulation
+
+```bash
+# Emulate dark color scheme
+playwright-cli run-code "async page => {
+  await page.emulateMedia({ colorScheme: 'dark' });
+}"
+
+# Emulate light color scheme
+playwright-cli run-code "async page => {
+  await page.emulateMedia({ colorScheme: 'light' });
+}"
+
+# Emulate reduced motion
+playwright-cli run-code "async page => {
+  await page.emulateMedia({ reducedMotion: 'reduce' });
+}"
+
+# Emulate print media
+playwright-cli run-code "async page => {
+  await page.emulateMedia({ media: 'print' });
+}"
+```
+
+## Wait Strategies
+
+```bash
+# Wait for network idle
+playwright-cli run-code "async page => {
+  await page.waitForLoadState('networkidle');
+}"
+
+# Wait for specific element
+playwright-cli run-code "async page => {
+  await page.locator('.loading').waitFor({ state: 'hidden' });
+}"
+
+# Wait for function to return true
+playwright-cli run-code "async page => {
+  await page.waitForFunction(() => window.appReady === true);
+}"
+
+# Wait with timeout
+playwright-cli run-code "async page => {
+  await page.locator('.result').waitFor({ timeout: 10000 });
+}"
+```
+
+## Frames and Iframes
+
+```bash
+# Work with iframe
+playwright-cli run-code "async page => {
+  const frame = page.locator('iframe#my-iframe').contentFrame();
+  await frame.locator('button').click();
+}"
+
+# Get all frames
+playwright-cli run-code "async page => {
+  const frames = page.frames();
+  return frames.map(f => f.url());
+}"
+```
+
+## File Downloads
+
+```bash
+# Handle file download
+playwright-cli run-code "async page => {
+  const downloadPromise = page.waitForEvent('download');
+  await page.getByRole('link', { name: 'Download' }).click();
+  const download = await downloadPromise;
+  await download.saveAs('./downloaded-file.pdf');
+  return download.suggestedFilename();
+}"
+```
+
+## Clipboard
+
+```bash
+# Read clipboard (requires permission)
+playwright-cli run-code "async page => {
+  await page.context().grantPermissions(['clipboard-read']);
+  return await page.evaluate(() => navigator.clipboard.readText());
+}"
+
+# Write to clipboard
+playwright-cli run-code "async page => {
+  await page.evaluate(text => navigator.clipboard.writeText(text), 'Hello clipboard!');
+}"
+```
+
+## Page Information
+
+```bash
+# Get page title
+playwright-cli run-code "async page => {
+  return await page.title();
+}"
+
+# Get current URL
+playwright-cli run-code "async page => {
+  return page.url();
+}"
+
+# Get page content
+playwright-cli run-code "async page => {
+  return await page.content();
+}"
+
+# Get viewport size
+playwright-cli run-code "async page => {
+  return page.viewportSize();
+}"
+```
+
+## JavaScript Execution
+
+```bash
+# Execute JavaScript and return result
+playwright-cli run-code "async page => {
+  return await page.evaluate(() => {
+    return {
+      userAgent: navigator.userAgent,
+      language: navigator.language,
+      cookiesEnabled: navigator.cookieEnabled
+    };
+  });
+}"
+
+# Pass arguments to evaluate
+playwright-cli run-code "async page => {
+  const multiplier = 5;
+  return await page.evaluate(m => document.querySelectorAll('li').length * m, multiplier);
+}"
+```
+
+## Error Handling
+
+```bash
+# Try-catch in run-code
+playwright-cli run-code "async page => {
+  try {
+    await page.getByRole('button', { name: 'Submit' }).click({ timeout: 1000 });
+    return 'clicked';
+  } catch (e) {
+    return 'element not found';
+  }
+}"
+```
+
+## Complex Workflows
+
+```bash
+# Login and save state
+playwright-cli run-code "async page => {
+  await page.goto('https://example.com/login');
+  await page.getByRole('textbox', { name: 'Email' }).fill('user@example.com');
+  await page.getByRole('textbox', { name: 'Password' }).fill('secret');
+  await page.getByRole('button', { name: 'Sign in' }).click();
+  await page.waitForURL('**/dashboard');
+  await page.context().storageState({ path: 'auth.json' });
+  return 'Login successful';
+}"
+
+# Scrape data from multiple pages
+playwright-cli run-code "async page => {
+  const results = [];
+  for (let i = 1; i <= 3; i++) {
+    await page.goto(\`https://example.com/page/\${i}\`);
+    const items = await page.locator('.item').allTextContents();
+    results.push(...items);
+  }
+  return results;
+}"
+```

--- a/.claude/skills/playwright-cli/references/session-management.md
+++ b/.claude/skills/playwright-cli/references/session-management.md
@@ -1,0 +1,225 @@
+# Browser Session Management
+
+Run multiple isolated browser sessions concurrently with state persistence.
+
+## Named Browser Sessions
+
+Use `-s` flag to isolate browser contexts:
+
+```bash
+# Browser 1: Authentication flow
+playwright-cli -s=auth open https://app.example.com/login
+
+# Browser 2: Public browsing (separate cookies, storage)
+playwright-cli -s=public open https://example.com
+
+# Commands are isolated by browser session
+playwright-cli -s=auth fill e1 "user@example.com"
+playwright-cli -s=public snapshot
+```
+
+## Browser Session Isolation Properties
+
+Each browser session has independent:
+- Cookies
+- LocalStorage / SessionStorage
+- IndexedDB
+- Cache
+- Browsing history
+- Open tabs
+
+## Browser Session Commands
+
+```bash
+# List all browser sessions
+playwright-cli list
+
+# Stop a browser session (close the browser)
+playwright-cli close                # stop the default browser
+playwright-cli -s=mysession close   # stop a named browser
+
+# Stop all browser sessions
+playwright-cli close-all
+
+# Forcefully kill all daemon processes (for stale/zombie processes)
+playwright-cli kill-all
+
+# Delete browser session user data (profile directory)
+playwright-cli delete-data                # delete default browser data
+playwright-cli -s=mysession delete-data   # delete named browser data
+```
+
+## Environment Variable
+
+Set a default browser session name via environment variable:
+
+```bash
+export PLAYWRIGHT_CLI_SESSION="mysession"
+playwright-cli open example.com  # Uses "mysession" automatically
+```
+
+## Common Patterns
+
+### Concurrent Scraping
+
+```bash
+#!/bin/bash
+# Scrape multiple sites concurrently
+
+# Start all browsers
+playwright-cli -s=site1 open https://site1.com &
+playwright-cli -s=site2 open https://site2.com &
+playwright-cli -s=site3 open https://site3.com &
+wait
+
+# Take snapshots from each
+playwright-cli -s=site1 snapshot
+playwright-cli -s=site2 snapshot
+playwright-cli -s=site3 snapshot
+
+# Cleanup
+playwright-cli close-all
+```
+
+### A/B Testing Sessions
+
+```bash
+# Test different user experiences
+playwright-cli -s=variant-a open "https://app.com?variant=a"
+playwright-cli -s=variant-b open "https://app.com?variant=b"
+
+# Compare
+playwright-cli -s=variant-a screenshot
+playwright-cli -s=variant-b screenshot
+```
+
+### Persistent Profile
+
+By default, browser profile is kept in memory only. Use `--persistent` flag on `open` to persist the browser profile to disk:
+
+```bash
+# Use persistent profile (auto-generated location)
+playwright-cli open https://example.com --persistent
+
+# Use persistent profile with custom directory
+playwright-cli open https://example.com --profile=/path/to/profile
+```
+
+## Attaching to a Running Browser
+
+Use `attach` to connect to a browser that is already running, instead of launching a new one.
+
+### Attach by channel name
+
+Connect to a running Chrome or Edge instance by its channel name. The browser must have remote debugging enabled — navigate to `chrome://inspect/#remote-debugging` in the target browser and check "Allow remote debugging for this browser instance".
+
+```bash
+# Attach to Chrome
+playwright-cli attach --cdp=chrome
+
+# Attach to Chrome Canary
+playwright-cli attach --cdp=chrome-canary
+
+# Attach to Microsoft Edge
+playwright-cli attach --cdp=msedge
+
+# Attach to Edge Dev
+playwright-cli attach --cdp=msedge-dev
+```
+
+Supported channels: `chrome`, `chrome-beta`, `chrome-dev`, `chrome-canary`, `msedge`, `msedge-beta`, `msedge-dev`, `msedge-canary`.
+
+When `--session` is not provided, the session is named after the channel (e.g. `--cdp=msedge` creates a session called `msedge`), so parallel attaches to Chrome and Edge don't collide on `default`. Pass `--session=<name>` to override.
+
+### Attach via CDP endpoint
+
+Connect to a browser that exposes a Chrome DevTools Protocol endpoint:
+
+```bash
+playwright-cli attach --cdp=http://localhost:9222
+```
+
+### Attach via browser extension
+
+Connect to a browser with the Playwright extension installed:
+
+```bash
+playwright-cli attach --extension
+```
+
+### Detach
+
+Tear down an attached session without affecting the external browser:
+
+```bash
+# Detach the default attached session
+playwright-cli detach
+
+# Detach a specific attached session
+playwright-cli -s=msedge detach
+```
+
+`detach` only works on sessions created via `attach`. For sessions created via `open`, use `close`.
+
+## Default Browser Session
+
+When `-s` is omitted, commands use the default browser session:
+
+```bash
+# These use the same default browser session
+playwright-cli open https://example.com
+playwright-cli snapshot
+playwright-cli close  # Stops default browser
+```
+
+## Browser Session Configuration
+
+Configure a browser session with specific settings when opening:
+
+```bash
+# Open with config file
+playwright-cli open https://example.com --config=.playwright/my-cli.json
+
+# Open with specific browser
+playwright-cli open https://example.com --browser=firefox
+
+# Open in headed mode
+playwright-cli open https://example.com --headed
+
+# Open with persistent profile
+playwright-cli open https://example.com --persistent
+```
+
+## Best Practices
+
+### 1. Name Browser Sessions Semantically
+
+```bash
+# GOOD: Clear purpose
+playwright-cli -s=github-auth open https://github.com
+playwright-cli -s=docs-scrape open https://docs.example.com
+
+# AVOID: Generic names
+playwright-cli -s=s1 open https://github.com
+```
+
+### 2. Always Clean Up
+
+```bash
+# Stop browsers when done
+playwright-cli -s=auth close
+playwright-cli -s=scrape close
+
+# Or stop all at once
+playwright-cli close-all
+
+# If browsers become unresponsive or zombie processes remain
+playwright-cli kill-all
+```
+
+### 3. Delete Stale Browser Data
+
+```bash
+# Remove old browser data to free disk space
+playwright-cli -s=oldsession delete-data
+```

--- a/.claude/skills/playwright-cli/references/storage-state.md
+++ b/.claude/skills/playwright-cli/references/storage-state.md
@@ -1,0 +1,275 @@
+# Storage Management
+
+Manage cookies, localStorage, sessionStorage, and browser storage state.
+
+## Storage State
+
+Save and restore complete browser state including cookies and storage.
+
+### Save Storage State
+
+```bash
+# Save to auto-generated filename (storage-state-{timestamp}.json)
+playwright-cli state-save
+
+# Save to specific filename
+playwright-cli state-save my-auth-state.json
+```
+
+### Restore Storage State
+
+```bash
+# Load storage state from file
+playwright-cli state-load my-auth-state.json
+
+# Reload page to apply cookies
+playwright-cli open https://example.com
+```
+
+### Storage State File Format
+
+The saved file contains:
+
+```json
+{
+  "cookies": [
+    {
+      "name": "session_id",
+      "value": "abc123",
+      "domain": "example.com",
+      "path": "/",
+      "expires": 1735689600,
+      "httpOnly": true,
+      "secure": true,
+      "sameSite": "Lax"
+    }
+  ],
+  "origins": [
+    {
+      "origin": "https://example.com",
+      "localStorage": [
+        { "name": "theme", "value": "dark" },
+        { "name": "user_id", "value": "12345" }
+      ]
+    }
+  ]
+}
+```
+
+## Cookies
+
+### List All Cookies
+
+```bash
+playwright-cli cookie-list
+```
+
+### Filter Cookies by Domain
+
+```bash
+playwright-cli cookie-list --domain=example.com
+```
+
+### Filter Cookies by Path
+
+```bash
+playwright-cli cookie-list --path=/api
+```
+
+### Get Specific Cookie
+
+```bash
+playwright-cli cookie-get session_id
+```
+
+### Set a Cookie
+
+```bash
+# Basic cookie
+playwright-cli cookie-set session abc123
+
+# Cookie with options
+playwright-cli cookie-set session abc123 --domain=example.com --path=/ --httpOnly --secure --sameSite=Lax
+
+# Cookie with expiration (Unix timestamp)
+playwright-cli cookie-set remember_me token123 --expires=1735689600
+```
+
+### Delete a Cookie
+
+```bash
+playwright-cli cookie-delete session_id
+```
+
+### Clear All Cookies
+
+```bash
+playwright-cli cookie-clear
+```
+
+### Advanced: Multiple Cookies or Custom Options
+
+For complex scenarios like adding multiple cookies at once, use `run-code`:
+
+```bash
+playwright-cli run-code "async page => {
+  await page.context().addCookies([
+    { name: 'session_id', value: 'sess_abc123', domain: 'example.com', path: '/', httpOnly: true },
+    { name: 'preferences', value: JSON.stringify({ theme: 'dark' }), domain: 'example.com', path: '/' }
+  ]);
+}"
+```
+
+## Local Storage
+
+### List All localStorage Items
+
+```bash
+playwright-cli localstorage-list
+```
+
+### Get Single Value
+
+```bash
+playwright-cli localstorage-get token
+```
+
+### Set Value
+
+```bash
+playwright-cli localstorage-set theme dark
+```
+
+### Set JSON Value
+
+```bash
+playwright-cli localstorage-set user_settings '{"theme":"dark","language":"en"}'
+```
+
+### Delete Single Item
+
+```bash
+playwright-cli localstorage-delete token
+```
+
+### Clear All localStorage
+
+```bash
+playwright-cli localstorage-clear
+```
+
+### Advanced: Multiple Operations
+
+For complex scenarios like setting multiple values at once, use `run-code`:
+
+```bash
+playwright-cli run-code "async page => {
+  await page.evaluate(() => {
+    localStorage.setItem('token', 'jwt_abc123');
+    localStorage.setItem('user_id', '12345');
+    localStorage.setItem('expires_at', Date.now() + 3600000);
+  });
+}"
+```
+
+## Session Storage
+
+### List All sessionStorage Items
+
+```bash
+playwright-cli sessionstorage-list
+```
+
+### Get Single Value
+
+```bash
+playwright-cli sessionstorage-get form_data
+```
+
+### Set Value
+
+```bash
+playwright-cli sessionstorage-set step 3
+```
+
+### Delete Single Item
+
+```bash
+playwright-cli sessionstorage-delete step
+```
+
+### Clear sessionStorage
+
+```bash
+playwright-cli sessionstorage-clear
+```
+
+## IndexedDB
+
+### List Databases
+
+```bash
+playwright-cli run-code "async page => {
+  return await page.evaluate(async () => {
+    const databases = await indexedDB.databases();
+    return databases;
+  });
+}"
+```
+
+### Delete Database
+
+```bash
+playwright-cli run-code "async page => {
+  await page.evaluate(() => {
+    indexedDB.deleteDatabase('myDatabase');
+  });
+}"
+```
+
+## Common Patterns
+
+### Authentication State Reuse
+
+```bash
+# Step 1: Login and save state
+playwright-cli open https://app.example.com/login
+playwright-cli snapshot
+playwright-cli fill e1 "user@example.com"
+playwright-cli fill e2 "password123"
+playwright-cli click e3
+
+# Save the authenticated state
+playwright-cli state-save auth.json
+
+# Step 2: Later, restore state and skip login
+playwright-cli state-load auth.json
+playwright-cli open https://app.example.com/dashboard
+# Already logged in!
+```
+
+### Save and Restore Roundtrip
+
+```bash
+# Set up authentication state
+playwright-cli open https://example.com
+playwright-cli eval "() => { document.cookie = 'session=abc123'; localStorage.setItem('user', 'john'); }"
+
+# Save state to file
+playwright-cli state-save my-session.json
+
+# ... later, in a new session ...
+
+# Restore state
+playwright-cli state-load my-session.json
+playwright-cli open https://example.com
+# Cookies and localStorage are restored!
+```
+
+## Security Notes
+
+- Never commit storage state files containing auth tokens
+- Add `*.auth-state.json` to `.gitignore`
+- Delete state files after automation completes
+- Use environment variables for sensitive data
+- By default, sessions run in-memory mode which is safer for sensitive operations

--- a/.claude/skills/playwright-cli/references/test-generation.md
+++ b/.claude/skills/playwright-cli/references/test-generation.md
@@ -1,0 +1,134 @@
+# Test Generation
+
+Generate Playwright test code automatically as you interact with the browser.
+
+## How It Works
+
+Every action you perform with `playwright-cli` generates corresponding Playwright TypeScript code.
+This code appears in the output and can be copied directly into your test files.
+
+## Example Workflow
+
+```bash
+# Start a session
+playwright-cli open https://example.com/login
+
+# Take a snapshot to see elements
+playwright-cli snapshot
+# Output shows: e1 [textbox "Email"], e2 [textbox "Password"], e3 [button "Sign In"]
+
+# Fill form fields - generates code automatically
+playwright-cli fill e1 "user@example.com"
+# Ran Playwright code:
+# await page.getByRole('textbox', { name: 'Email' }).fill('user@example.com');
+
+playwright-cli fill e2 "password123"
+# Ran Playwright code:
+# await page.getByRole('textbox', { name: 'Password' }).fill('password123');
+
+playwright-cli click e3
+# Ran Playwright code:
+# await page.getByRole('button', { name: 'Sign In' }).click();
+```
+
+## Building a Test File
+
+Collect the generated code into a Playwright test:
+
+```typescript
+import { test, expect } from '@playwright/test';
+
+test('login flow', async ({ page }) => {
+  // Generated code from playwright-cli session:
+  await page.goto('https://example.com/login');
+  await page.getByRole('textbox', { name: 'Email' }).fill('user@example.com');
+  await page.getByRole('textbox', { name: 'Password' }).fill('password123');
+  await page.getByRole('button', { name: 'Sign In' }).click();
+
+  // Add assertions
+  await expect(page).toHaveURL(/.*dashboard/);
+});
+```
+
+## Best Practices
+
+### 1. Use Semantic Locators
+
+The generated code uses role-based locators when possible, which are more resilient:
+
+```typescript
+// Generated (good - semantic)
+await page.getByRole('button', { name: 'Submit' }).click();
+
+// Avoid (fragile - CSS selectors)
+await page.locator('#submit-btn').click();
+```
+
+### 2. Explore Before Recording
+
+Take snapshots to understand the page structure before recording actions:
+
+```bash
+playwright-cli open https://example.com
+playwright-cli snapshot
+# Review the element structure
+playwright-cli click e5
+```
+
+### 3. Add Assertions Manually
+
+Generated code captures actions but not assertions. Add expectations in your test using one of the recommended matchers:
+
+- `toBeVisible()` — element is rendered and visible
+- `toHaveText(text)` — element text content matches
+- `toHaveValue(value) / toBeEmpty()` — input/select value matches
+- `toBeChecked() / toBeUnchecked()` — checkbox state matches
+- `toMatchAriaSnapshot(snapshot)` — page (or locator) matches a partial accessibility snapshot
+
+Use `playwright-cli generate-locator <target>` to produce the locator expression for the assertion, and the snapshot/eval commands to capture the expected value.
+
+When asserting text content, make sure that generated locator does not contain text from the element itself. `getByTestId()` or `getByLabel()` usually work well with asserting text. When locator is text-based, prefer `toBeVisible()` instead.
+
+Snapshot to be matched does not have to contain all the information - only capture what's necessary for the assertion. You can use regular expressions for unstable values.
+
+```bash
+# Get a stable locator for an element ref to use in the assertion
+playwright-cli --raw generate-locator e5
+# getByRole('button', { name: 'Submit' })
+
+# Capture expected text content for toHaveText
+playwright-cli --raw eval "el => el.textContent" e5
+
+# Capture expected input value for toHaveValue/toBeEmpty
+playwright-cli --raw eval "el => el.value" e5
+
+# Capture expected aria snapshot for toMatchAriaSnapshot/toBeChecked
+# (whole page, or use a ref to scope to a region)
+playwright-cli --raw snapshot
+playwright-cli --raw snapshot e5
+```
+
+```typescript
+// Generated action
+await page.getByRole('button', { name: 'Submit' }).click();
+
+// Manual assertions using the outputs above:
+await expect(page.getByRole('alert', { name: 'Success' })).toBeVisible();
+await expect(page.getByTestId('main-header')).toHaveText('Welcome, user');
+await expect(page.getByRole('textbox', { name: 'Email' })).toHaveValue('user@example.com');
+await expect(page.getByRole('checkbox', { name: 'Enable notifications' })).toBeChecked();
+
+// toMatchAriaSnapshot on the whole page, finds a matching region
+await expect(page).toMatchAriaSnapshot(`
+  - heading "Welcome, user"
+  - link /\\d+ new messages?/
+  - button "Sign out"
+`);
+
+// toMatchAriaSnapshot scoped to a region
+await expect(page.getByRole('navigation')).toMatchAriaSnapshot(`
+  - link "Home"
+  - link /\\d+ new messages?/
+  - link "Profile"
+`);
+```

--- a/.claude/skills/playwright-cli/references/tracing.md
+++ b/.claude/skills/playwright-cli/references/tracing.md
@@ -1,0 +1,139 @@
+# Tracing
+
+Capture detailed execution traces for debugging and analysis. Traces include DOM snapshots, screenshots, network activity, and console logs.
+
+## Basic Usage
+
+```bash
+# Start trace recording
+playwright-cli tracing-start
+
+# Perform actions
+playwright-cli open https://example.com
+playwright-cli click e1
+playwright-cli fill e2 "test"
+
+# Stop trace recording
+playwright-cli tracing-stop
+```
+
+## Trace Output Files
+
+When you start tracing, Playwright creates a `traces/` directory with several files:
+
+### `trace-{timestamp}.trace`
+
+**Action log** - The main trace file containing:
+- Every action performed (clicks, fills, navigations)
+- DOM snapshots before and after each action
+- Screenshots at each step
+- Timing information
+- Console messages
+- Source locations
+
+### `trace-{timestamp}.network`
+
+**Network log** - Complete network activity:
+- All HTTP requests and responses
+- Request headers and bodies
+- Response headers and bodies
+- Timing (DNS, connect, TLS, TTFB, download)
+- Resource sizes
+- Failed requests and errors
+
+### `resources/`
+
+**Resources directory** - Cached resources:
+- Images, fonts, stylesheets, scripts
+- Response bodies for replay
+- Assets needed to reconstruct page state
+
+## What Traces Capture
+
+| Category | Details |
+|----------|---------|
+| **Actions** | Clicks, fills, hovers, keyboard input, navigations |
+| **DOM** | Full DOM snapshot before/after each action |
+| **Screenshots** | Visual state at each step |
+| **Network** | All requests, responses, headers, bodies, timing |
+| **Console** | All console.log, warn, error messages |
+| **Timing** | Precise timing for each operation |
+
+## Use Cases
+
+### Debugging Failed Actions
+
+```bash
+playwright-cli tracing-start
+playwright-cli open https://app.example.com
+
+# This click fails - why?
+playwright-cli click e5
+
+playwright-cli tracing-stop
+# Open trace to see DOM state when click was attempted
+```
+
+### Analyzing Performance
+
+```bash
+playwright-cli tracing-start
+playwright-cli open https://slow-site.com
+playwright-cli tracing-stop
+
+# View network waterfall to identify slow resources
+```
+
+### Capturing Evidence
+
+```bash
+# Record a complete user flow for documentation
+playwright-cli tracing-start
+
+playwright-cli open https://app.example.com/checkout
+playwright-cli fill e1 "4111111111111111"
+playwright-cli fill e2 "12/25"
+playwright-cli fill e3 "123"
+playwright-cli click e4
+
+playwright-cli tracing-stop
+# Trace shows exact sequence of events
+```
+
+## Trace vs Video vs Screenshot
+
+| Feature | Trace | Video | Screenshot |
+|---------|-------|-------|------------|
+| **Format** | .trace file | .webm video | .png/.jpeg image |
+| **DOM inspection** | Yes | No | No |
+| **Network details** | Yes | No | No |
+| **Step-by-step replay** | Yes | Continuous | Single frame |
+| **File size** | Medium | Large | Small |
+| **Best for** | Debugging | Demos | Quick capture |
+
+## Best Practices
+
+### 1. Start Tracing Before the Problem
+
+```bash
+# Trace the entire flow, not just the failing step
+playwright-cli tracing-start
+playwright-cli open https://example.com
+# ... all steps leading to the issue ...
+playwright-cli tracing-stop
+```
+
+### 2. Clean Up Old Traces
+
+Traces can consume significant disk space:
+
+```bash
+# Remove traces older than 7 days
+find .playwright-cli/traces -mtime +7 -delete
+```
+
+## Limitations
+
+- Traces add overhead to automation
+- Large traces can consume significant disk space
+- Some dynamic content may not replay perfectly

--- a/.claude/skills/playwright-cli/references/video-recording.md
+++ b/.claude/skills/playwright-cli/references/video-recording.md
@@ -1,0 +1,143 @@
+# Video Recording
+
+Capture browser automation sessions as video for debugging, documentation, or verification. Produces WebM (VP8/VP9 codec).
+
+## Basic Recording
+
+```bash
+# Open browser first
+playwright-cli open
+
+# Start recording
+playwright-cli video-start demo.webm
+
+# Add a chapter marker for section transitions
+playwright-cli video-chapter "Getting Started" --description="Opening the homepage" --duration=2000
+
+# Navigate and perform actions
+playwright-cli goto https://example.com
+playwright-cli snapshot
+playwright-cli click e1
+
+# Add another chapter
+playwright-cli video-chapter "Filling Form" --description="Entering test data" --duration=2000
+playwright-cli fill e2 "test input"
+
+# Stop and save
+playwright-cli video-stop
+```
+
+## Best Practices
+
+### 1. Use Descriptive Filenames
+
+```bash
+# Include context in filename
+playwright-cli video-start recordings/login-flow-2024-01-15.webm
+playwright-cli video-start recordings/checkout-test-run-42.webm
+```
+
+### 2. Record entire hero scripts.
+
+When recording a video for the user or as a proof of work, it is best to create a code snippet and execute it with run-code.
+It allows pulling appropriate pauses between the actions and annotating the video. There are new Playwright APIs for that.
+
+1) Perform scenario using CLI and take note of all locators and actions. You'll need those locators to request their bounding boxes for highlight.
+2) Create a file with the intended script for video (below). Use pressSequentially w/ delay for nice typing, make reasonable pauses.
+3) Use playwright-cli run-code --filename your-script.js
+
+**Important**: Overlays are `pointer-events: none` — they do not interfere with page interactions. You can safely keep sticky overlays visible while clicking, filling, or performing any actions on the page.
+
+```js
+async page => {
+  await page.screencast.start({ path: 'video.webm', size: { width: 1280, height: 800 } });
+  await page.goto('https://demo.playwright.dev/todomvc');
+
+  // Show a chapter card — blurs the page and shows a dialog.
+  // Blocks until duration expires, then auto-removes.
+  // Use this for simple use cases, but always feel free to hand-craft your own beautiful
+  // overlay via await page.screencast.showOverlay().
+  await page.screencast.showChapter('Adding Todo Items', {
+    description: 'We will add several items to the todo list.',
+    duration: 2000,
+  });
+
+  // Perform action
+  await page.getByRole('textbox', { name: 'What needs to be done?' }).pressSequentially('Walk the dog', { delay: 60 });
+  await page.getByRole('textbox', { name: 'What needs to be done?' }).press('Enter');
+  await page.waitForTimeout(1000);
+
+  // Show next chapter
+  await page.screencast.showChapter('Verifying Results', {
+    description: 'Checking the item appeared in the list.',
+    duration: 2000,
+  });
+
+  // Add a sticky annotation that stays while you perform actions.
+  // Overlays are pointer-events: none, so they won't block clicks.
+  const annotation = await page.screencast.showOverlay(`
+    <div style="position: absolute; top: 8px; right: 8px;
+      padding: 6px 12px; background: rgba(0,0,0,0.7);
+      border-radius: 8px; font-size: 13px; color: white;">
+      ✓ Item added successfully
+    </div>
+  `);
+
+  // Perform more actions while the annotation is visible
+  await page.getByRole('textbox', { name: 'What needs to be done?' }).pressSequentially('Buy groceries', { delay: 60 });
+  await page.getByRole('textbox', { name: 'What needs to be done?' }).press('Enter');
+  await page.waitForTimeout(1500);
+
+  // Remove the annotation when done
+  await annotation.dispose();
+
+  // You can also highlight relevant locators and provide contextual annotations.
+  const bounds = await page.getByText('Walk the dog').boundingBox();
+  await page.screencast.showOverlay(`
+    <div style="position: absolute;
+      top: ${bounds.y}px;
+      left: ${bounds.x}px;
+      width: ${bounds.width}px;
+      height: ${bounds.height}px;
+      border: 1px solid red;">
+    </div>
+    <div style="position: absolute;
+      top: ${bounds.y + bounds.height + 5}px;
+      left: ${bounds.x + bounds.width / 2}px;
+      transform: translateX(-50%);
+      padding: 6px;
+      background: #808080;
+      border-radius: 10px;
+      font-size: 14px;
+      color: white;">Check it out, it is right above this text
+    </div>
+  `, { duration: 2000 });
+
+  await page.screencast.stop();
+}
+```
+
+Embrace creativity, overlays are powerful.
+
+### Overlay API Summary
+
+| Method | Use Case |
+|--------|----------|
+| `page.screencast.showChapter(title, { description?, duration?, styleSheet? })` | Full-screen chapter card with blurred backdrop — ideal for section transitions |
+| `page.screencast.showOverlay(html, { duration? })` | Custom HTML overlay — use for callouts, labels, highlights |
+| `disposable.dispose()` | Remove a sticky overlay added without duration |
+| `page.screencast.hideOverlays()` / `page.screencast.showOverlays()` | Temporarily hide/show all overlays |
+
+## Tracing vs Video
+
+| Feature | Video | Tracing |
+|---------|-------|---------|
+| Output | WebM file | Trace file (viewable in Trace Viewer) |
+| Shows | Visual recording | DOM snapshots, network, console, actions |
+| Use case | Demos, documentation | Debugging, analysis |
+| Size | Larger | Smaller |
+
+## Limitations
+
+- Recording adds slight overhead to automation
+- Large recordings can consume significant disk space

--- a/.claude/skills/review-ui-on-browser/SKILL.md
+++ b/.claude/skills/review-ui-on-browser/SKILL.md
@@ -1,9 +1,12 @@
 ---
 name: review-ui-on-browser
-description: Visual UI/UX review of a running localhost dev server using Playwright CLI. Use when the user wants Claude to look at the actual rendered UI on the browser (not just static code) and produce findings on hierarchy, spacing, primary action visibility, loading/empty/error states, and content readability. Manually invoked — not wired into autonomous routines.
+description: Visual UI/UX review of a running dev server using the playwright-cli skill. Use when the user wants Claude to look at the actual rendered UI on the browser (not just static code) and produce findings on hierarchy, spacing, primary action visibility, loading/empty/error states, and content readability. Manually invoked — not wired into autonomous routines.
+allowed-tools: Bash(playwright-cli:*) Bash(npx:*) Bash(npm:*)
 ---
 
 # Review UI On Browser
+
+> This skill drives the browser through the sibling **`playwright-cli`** skill (Microsoft's `@playwright/cli`, https://github.com/microsoft/playwright-cli). See `.claude/skills/playwright-cli/SKILL.md` for the full command reference. This file describes only the review workflow on top of those commands.
 
 ## When to invoke
 
@@ -15,27 +18,32 @@ NOT invoked from:
 - `ds-client-constrained-execution` skill (intentional — Vercel preview auth + per-branch URL constraints make this impractical for autonomous use)
 - Autonomous nightly routine (same)
 
-## Prerequisites (one-time setup on the user's Mac)
+## Prerequisites (one-time setup)
+
+`playwright-cli` must be installed. Defer to the `playwright-cli` skill's own install section. Quick check:
 
 ```bash
-# In ANY directory — Playwright manages its own browser binaries:
-npx playwright install chromium
+npx --no-install playwright-cli --version              # check CLI
+npm install -g @playwright/cli@latest                  # install CLI if missing
+npx playwright-cli install-browser chrome-for-testing  # install browser binary (~92 MB, one-time)
 ```
 
-This downloads the Chromium browser binary (~150MB, ~2 min). Once installed, subsequent invocations skip this step.
+The CLI install does NOT bring the browser binary. The first `open --browser=chromium` will fail with `Browser "chrome-for-testing" is not installed` until `install-browser` is run.
+
+If either step is missing, fail early with the install instruction — do NOT silently install.
 
 ## Prerequisites (per invocation)
 
 The user must have:
 1. Checked out the branch they want to review
 2. Started the dev server (`cd ../KISA-website/client && npm run dev`)
-3. Confirmed the dev server is reachable at the URL they pass to the skill (default `http://localhost:3000`)
+3. Confirmed the dev server is reachable at the URL they pass to the skill (use the devtunnels URL the user provides — never `localhost`)
 
 The skill does NOT start the dev server. It assumes the running server.
 
 ## Inputs (the user tells the skill these)
 
-- **Base URL** (default `http://localhost:3000`)
+- **Base URL** (devtunnels URL the user provides, e.g., `https://vnw20xbg-3000.asse.devtunnels.ms`)
 - **Routes** to visit (e.g., `["/pocha/manage", "/pocha/manage/?dialog=open"]`)
 - **Key flows** (optional — descriptions like "open the create dialog, fill the info tab, switch to menu tab")
 - **Viewports** (default `[{ width: 1280, height: 800, label: "desktop" }, { width: 375, height: 812, label: "mobile" }]`)
@@ -43,15 +51,34 @@ The skill does NOT start the dev server. It assumes the running server.
 
 ## Process
 
-For each route × viewport combination:
+Use a single named session (`-s=review`) so all commands target the same browser instance. Open once, drive through all routes/viewports, close at the end.
 
-1. Launch a headless browser via `npx playwright`
-2. Navigate to `<baseURL><route>`
-3. Set viewport size
-4. Wait for `networkidle`
-5. Screenshot — save to `/tmp/review-ui-on-browser/<timestamp>/<route-slug>-<viewport-label>.png`
-6. Capture the accessibility tree (Playwright `page.accessibility.snapshot()`)
-7. If a flow is described, walk through it (click selectors, fill inputs) — screenshot at each step
+```bash
+# 1. Open the session (headless by default)
+playwright-cli -s=review open --browser=chromium
+
+# 2. For each route × viewport:
+playwright-cli -s=review goto <baseURL><route>
+playwright-cli -s=review resize 1280 800
+playwright-cli -s=review snapshot --filename=/tmp/review-ui-on-browser/<ts>/<slug>-desktop.yml
+playwright-cli -s=review screenshot --filename=/tmp/review-ui-on-browser/<ts>/<slug>-desktop.png
+playwright-cli -s=review resize 375 812
+playwright-cli -s=review snapshot --filename=/tmp/review-ui-on-browser/<ts>/<slug>-mobile.yml
+playwright-cli -s=review screenshot --filename=/tmp/review-ui-on-browser/<ts>/<slug>-mobile.png
+
+# 3. For each described flow: snapshot to get refs, then drive
+playwright-cli -s=review snapshot                         # read refs (e3, e15, …)
+playwright-cli -s=review click e15
+playwright-cli -s=review fill e7 "사장님"
+playwright-cli -s=review screenshot --filename=...-step-N.png
+
+# 4. Close
+playwright-cli -s=review close
+```
+
+The `playwright-cli snapshot` YAML is the accessibility tree with refs — that's both the a11y capture and the source of element refs for interaction.
+
+`playwright-cli` auto-stabilizes after each command, so explicit `networkidle` waits aren't needed. If a route does need an extra wait (e.g., post-mount async fetch), use `playwright-cli -s=review eval "..."` as the escape hatch.
 
 After captures, review every screenshot against the rubric below and return findings.
 
@@ -127,16 +154,18 @@ Result: PASS — no findings
 
 ## Implementation notes
 
-- Use `npx playwright codegen` patterns mentally; do not actually invoke codegen
-- Run Playwright in headless mode (`--headed` is for the user to debug, not for the skill)
-- Capture each screenshot as PNG
-- The screenshots are the primary artifact — text findings reference them with absolute paths so the user can open them
-- If `npx playwright install chromium` has not been run, fail early with the install instruction — do NOT silently install
-- Do not modify any client files. Do not run dev server. Do not commit anything.
+- Always use a single named session (`-s=review`) so `resize`, `snapshot`, `screenshot`, `click`, `fill` all hit the same browser instance. Close it at the end with `playwright-cli -s=review close`.
+- For element interaction, **always `snapshot` first** to get refs (`e3`, `e15`, …), then `click eN` / `fill eN "..."`. Don't guess refs — they're only valid relative to the most recent snapshot.
+- `playwright-cli` is headless by default — don't pass `--headed` (that's for the user to debug interactively, not for the skill).
+- Capture each screenshot as PNG via `--filename=...png`.
+- The screenshots are the primary artifact — text findings reference them with absolute paths so the user can open them.
+- Do not modify any client files. Do not start the dev server. Do not commit anything.
 
 ## Common pitfalls
 
-- Forgetting to wait for `networkidle` before screenshot → captures loading skeleton instead of loaded UI
-- Mixing up base URL with route — base URL is `http://localhost:3000`, route is `/pocha/manage`
-- Reviewing only desktop — always include mobile (375px) at minimum
-- Reporting findings without absolute screenshot paths — the user must be able to open the image to verify
+- Forgetting `-s=review` on a follow-up command → opens a fresh browser, loses session state.
+- Calling `click eN` without a fresh `snapshot` first → stale or wrong ref → wrong element clicked.
+- Using `localhost` URLs → use the devtunnels URL the user provides (per environment constraints).
+- Mixing up base URL with route — base URL is the devtunnels host, route is `/pocha/manage`.
+- Reviewing only desktop — always include mobile (375px) at minimum.
+- Reporting findings without absolute screenshot paths — the user must be able to open the image to verify.

--- a/.claude/skills/review-ui-on-browser/SKILL.md
+++ b/.claude/skills/review-ui-on-browser/SKILL.md
@@ -1,0 +1,142 @@
+---
+name: review-ui-on-browser
+description: Visual UI/UX review of a running localhost dev server using Playwright CLI. Use when the user wants Claude to look at the actual rendered UI on the browser (not just static code) and produce findings on hierarchy, spacing, primary action visibility, loading/empty/error states, and content readability. Manually invoked — not wired into autonomous routines.
+---
+
+# Review UI On Browser
+
+## When to invoke
+
+Manually, by the user, during:
+- **Mode C (PR review)** — after checking out the branch and starting the dev server, before merge approval, to catch visual issues a human reviewer might miss
+- **Mode D (interactive execution)** — after a UI-touching task completes, before `git commit`, to sanity-check the rendered result
+
+NOT invoked from:
+- `ds-client-constrained-execution` skill (intentional — Vercel preview auth + per-branch URL constraints make this impractical for autonomous use)
+- Autonomous nightly routine (same)
+
+## Prerequisites (one-time setup on the user's Mac)
+
+```bash
+# In ANY directory — Playwright manages its own browser binaries:
+npx playwright install chromium
+```
+
+This downloads the Chromium browser binary (~150MB, ~2 min). Once installed, subsequent invocations skip this step.
+
+## Prerequisites (per invocation)
+
+The user must have:
+1. Checked out the branch they want to review
+2. Started the dev server (`cd ../KISA-website/client && npm run dev`)
+3. Confirmed the dev server is reachable at the URL they pass to the skill (default `http://localhost:3000`)
+
+The skill does NOT start the dev server. It assumes the running server.
+
+## Inputs (the user tells the skill these)
+
+- **Base URL** (default `http://localhost:3000`)
+- **Routes** to visit (e.g., `["/pocha/manage", "/pocha/manage/?dialog=open"]`)
+- **Key flows** (optional — descriptions like "open the create dialog, fill the info tab, switch to menu tab")
+- **Viewports** (default `[{ width: 1280, height: 800, label: "desktop" }, { width: 375, height: 812, label: "mobile" }]`)
+- **What changed** (a 1–2 sentence summary of what the user wants reviewed — e.g., "the PochaForm dialog redesign with sticky footer")
+
+## Process
+
+For each route × viewport combination:
+
+1. Launch a headless browser via `npx playwright`
+2. Navigate to `<baseURL><route>`
+3. Set viewport size
+4. Wait for `networkidle`
+5. Screenshot — save to `/tmp/review-ui-on-browser/<timestamp>/<route-slug>-<viewport-label>.png`
+6. Capture the accessibility tree (Playwright `page.accessibility.snapshot()`)
+7. If a flow is described, walk through it (click selectors, fill inputs) — screenshot at each step
+
+After captures, review every screenshot against the rubric below and return findings.
+
+## Rubric
+
+For each screenshot, evaluate:
+
+### Hierarchy
+- Is the primary action visually prominent (size, color, position)?
+- Are headings clearly differentiated by size + weight from body text?
+- Does the visual order match the intended reading order?
+
+### Spacing rhythm
+- Consistent gap tier within sections? (No `gap-2` jumping to `gap-6` arbitrarily)
+- Page padding consistent with siblings on adjacent routes?
+- Component-internal padding feels deliberate, not cramped or floating?
+
+### Primary action visibility
+- Can the user tell what to do next within 2 seconds of looking?
+- Disabled / loading states distinct from the active state?
+- Submit button position predictable (sticky footer for forms, end of card for actions)?
+
+### State coverage
+- Loading: a skeleton, spinner, or text placeholder is visible during data fetch
+- Empty: empty state has helpful text + (if applicable) a primary action to fill it
+- Error: error state has a clear message + recovery path
+- All three states reachable in the routes/flows visited
+
+### Content readability
+- Body text uses primary foreground color (not muted-foreground for content the user must read)
+- Status content uses semantic colors (success/warning/error/info), not muted neutrals
+- No content overflow / text clipping at either viewport
+- Korean + English text both render with their intended type tier
+
+### Mobile (375px) specifics
+- Tap targets ≥ 44×44 px
+- No horizontal scroll on the body
+- Modals / dialogs adapt to viewport (no offscreen content)
+- Sticky footer stays in view during keyboard open (best-effort; flag if you can't tell)
+
+## Output format
+
+Per finding:
+
+```
+FINDING N [BLOCK|SUGGEST|INFO]
+Screenshot: /tmp/review-ui-on-browser/<timestamp>/<route-slug>-<viewport-label>.png
+Route: <route>
+Viewport: <viewport label>
+Smell: <one-line problem>
+Suggested fix: <concrete change in code or design>
+```
+
+Severity:
+- **BLOCK** — broken UX (overflow, content unreachable, primary action invisible, error state missing)
+- **SUGGEST** — visible polish issue (spacing rhythm, hierarchy off, status badge wrong variant)
+- **INFO** — minor polish or alternative
+
+End with a summary:
+
+```
+---
+Reviewed: <N> route(s) × <M> viewport(s)
+Screenshots: /tmp/review-ui-on-browser/<timestamp>/
+Result: B BLOCK, S SUGGEST, I INFO finding(s)
+```
+
+If clean:
+
+```
+Result: PASS — no findings
+```
+
+## Implementation notes
+
+- Use `npx playwright codegen` patterns mentally; do not actually invoke codegen
+- Run Playwright in headless mode (`--headed` is for the user to debug, not for the skill)
+- Capture each screenshot as PNG
+- The screenshots are the primary artifact — text findings reference them with absolute paths so the user can open them
+- If `npx playwright install chromium` has not been run, fail early with the install instruction — do NOT silently install
+- Do not modify any client files. Do not run dev server. Do not commit anything.
+
+## Common pitfalls
+
+- Forgetting to wait for `networkidle` before screenshot → captures loading skeleton instead of loaded UI
+- Mixing up base URL with route — base URL is `http://localhost:3000`, route is `/pocha/manage`
+- Reviewing only desktop — always include mobile (375px) at minimum
+- Reporting findings without absolute screenshot paths — the user must be able to open the image to verify

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ node_modules/
 *.log
 .DS_Store
 .worktrees/
+.playwright-cli/
 
 # agent settings
 .claude/settings.local.json

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,10 +33,10 @@ Wait for user confirmation. NEVER execute without explicit go-ahead.
 
 | Mode | Load |
 |---|---|
-| A | `docs/plans/client-migration/HARNESS_DESIGN.md` (Per-Phase Internal Flow); `docs/plans/client-migration/AUTONOMOUS_PROTOCOL.md` §3 (issue template) |
-| B | `AUTONOMOUS_PROTOCOL.md` §3 (issue template), §4 (6-rule autonomous gate) |
-| C1 / C2 | `review-pr-queue` skill (handles its own loads) |
-| D | `ds-client-constrained-execution` skill (handles its own loads) |
+| A | `docs/plans/client-migration/HARNESS_DESIGN.md` (Per-Phase Internal Flow); `AUTONOMOUS_PROTOCOL.md` Part 2 (§5 issue template) |
+| B | `AUTONOMOUS_PROTOCOL.md` Part 2 (§5 issue template + §6 6-rule gate) |
+| C1 / C2 | `review-pr-queue` skill (handles its own loads); `AUTONOMOUS_PROTOCOL.md` §3 only if mode flow needs disambiguation |
+| D | `ds-client-constrained-execution` skill (handles its own loads); `AUTONOMOUS_PROTOCOL.md` §11 lane-state annotation |
 | E | `ds-phase-end-bump` skill; HARNESS_DESIGN.md "Phase close-out" section |
 
 `docs/DS_CODEBASE.md` is loaded only if the current task involves DS surface discovery (typically Mode A grill or Mode D when a new component is needed). Implementers in Mode D execution use `docs/DS_CLIENT_USAGE.md` instead.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,16 +4,42 @@
 
 ### Cold-Session Startup
 
-**Preflight** (run every cold session):
+**Preflight** (run every cold session — minimal universal load):
 
 1. Read `docs/TODO.md` → find first unchecked entry under "## Client Migration"
-2. Read `docs/plans/client-migration/HARNESS_DESIGN.md` → full harness context
-3. **DS symlink check** (Phase 0+): `ls -la ../KISA-website/client/node_modules/@umichkisa-ds/web` — if not `->` symlink, run `bash ../KISA-website/client/scripts/link-ds.sh` (requires DS `dist/`; run `pnpm build` first if missing).
-4. Read `docs/DS_CODEBASE.md` → know what DS components are available
+2. **DS symlink check** (Phase 0+): `ls -la ../KISA-website/client/node_modules/@umichkisa-ds/web` — if not `->` symlink, run `bash ../KISA-website/client/scripts/link-ds.sh` (requires DS `dist/`; run `pnpm build` first if missing)
 
-Derive phase folder: `docs/plans/client-migration/phase-<N>-<slug>/`. Subphases share the phase-root `audit.md` / `plan.md` / `notes.md` — no per-subphase subfolders.
+**Mode detection** (inlined from `AUTONOMOUS_PROTOCOL.md` §10 — do this without loading AP):
 
-Detect repo state (`audit.md`/`plan.md` presence, open PRs/issues for `phase-<N>`), then propose one of five modes per `AUTONOMOUS_PROTOCOL.md` §10 (A audit / B plan + issues / C PR review / D interactive execute / E close-out). Confirm with user before proceeding.
+Derive the phase folder: `docs/plans/client-migration/phase-<N>-<slug>/` (where `<N>-<slug>` matches the first unchecked phase in TODO).
+
+Then check repo state:
+
+| Signal | Mode |
+|---|---|
+| `audit.md` missing in phase folder | **Mode A** — Audit writing |
+| `audit.md` exists, `plan.md` missing | **Mode B** — Plan writing + issue generation |
+| Sitting PR(s) for `phase-<N>`; selected PR has neither `needs-decision` nor `needs-interactive` label, CI green | **Mode C1** — PR review (ready-to-merge) |
+| Sitting PR(s) for `phase-<N>`; selected PR has `needs-decision` or `needs-interactive` label | **Mode C2** — PR review (interactive/decision) |
+| `plan.md` exists, open `needs-interactive` issues without linked PRs (or user override to execute live) | **Mode D** — Interactive execution |
+| All lanes merged for the phase | **Mode E** — Phase close-out |
+
+**Propose, don't execute.** Say:
+> "I see [state summary]. Likely mode: **X**. Proceed with Mode X, or pick a different mode?"
+
+Wait for user confirmation. NEVER execute without explicit go-ahead.
+
+**Mode-specific lazy loads** (load only when mode is confirmed):
+
+| Mode | Load |
+|---|---|
+| A | `docs/plans/client-migration/HARNESS_DESIGN.md` (Per-Phase Internal Flow); `docs/plans/client-migration/AUTONOMOUS_PROTOCOL.md` §3 (issue template) |
+| B | `AUTONOMOUS_PROTOCOL.md` §3 (issue template), §4 (6-rule autonomous gate) |
+| C1 / C2 | `review-pr-queue` skill (handles its own loads) |
+| D | `ds-client-constrained-execution` skill (handles its own loads) |
+| E | `ds-phase-end-bump` skill; HARNESS_DESIGN.md "Phase close-out" section |
+
+`docs/DS_CODEBASE.md` is loaded only if the current task involves DS surface discovery (typically Mode A grill or Mode D when a new component is needed). Implementers in Mode D execution use `docs/DS_CLIENT_USAGE.md` instead.
 
 ### Wrapping up a merged PR / lane
 

--- a/docs/DS_CLIENT_USAGE.md
+++ b/docs/DS_CLIENT_USAGE.md
@@ -6,14 +6,24 @@ _For author-side rules (building DS components), see `DS_CONSTRAINTS.md`._
 
 ---
 
-## Setup
+## Part 1 — Write-Time Decision Tree
 
-### CSS Entry Point
+_Read this BEFORE writing any line of client code that touches UI. Implementers: this is your write-time cheat sheet. Reviewers: skip to Part 2 — Review-Time Rulebook below._
+
+---
+
+## Part 2 — Review-Time Rulebook
+
+_Full constraint taxonomy. The `ds-client-review` agent scans this end-to-end._
+
+### Setup
+
+#### CSS Entry Point
 
 Must: For Tailwind v4 consumers (the standard case — all current KISA apps), import `@umichkisa-ds/web/theme.css` in the app's Tailwind-processed CSS entry (e.g. `globals.css`). This re-exports the DS source so the consumer's own Tailwind build emits DS tokens + utilities + component classes against actual client usage. [source:phase-0-gap/2026-04-18]
 Never: Import `@umichkisa-ds/web/dist/styles.css` in a Tailwind v4 consumer. The precompiled bundle is tree-shaken against DS source only, so utilities like `bg-brand-primary`, `text-foreground`, `border-border-strong` used in the client's JSX resolve to nothing at runtime — silent visual breakage. Use `dist/styles.css` only from non-Tailwind consumers that can't compile the source. [source:phase-0-gap/2026-04-18]
 
-### Font Loading (Next.js)
+#### Font Loading (Next.js)
 
 Must: Load SejongHospital Bold and Light via `next/font/local`, using the exact CSS variable names `--font-sejong-bold` and `--font-sejong-light`, with `display: 'swap'`. Apply both `.variable` classes to the `<html>` element. This overrides the baseline `@font-face` from `styles.css` with preloaded, optimized fonts. [source:docs-app/foundation/typography/fonts]
 Must: Load Pretendard Variable via CDN — add `<link rel="preconnect" href="https://cdn.jsdelivr.net">` and the stylesheet link to `https://cdn.jsdelivr.net/gh/orioncactus/pretendard@v1.3.9/dist/web/variable/pretendardvariable.min.css` in the document `<head>`. [source:docs-app/foundation/typography/fonts]
@@ -22,13 +32,13 @@ Never: Load Geist Mono (`font-geist-mono`) in client apps — it is a documentat
 
 ---
 
-## Component Usage
+### Component Usage
 
 Must: Check `DS_CODEBASE.md` before building any local UI component — if a DS equivalent exists, use it. [source:HARNESS_DESIGN.md/missing-ds-components]
 Must: Use DS components directly by importing from `@umichkisa-ds/web` or `@umichkisa-ds/form`. [source:DS_CODEBASE.md/packages]
 Never: Wrap or re-export a DS component to add default props or rename it (e.g., no `MyButton` that re-exports `Button`). This creates a shadow component layer that drifts from the DS over time. [source:grill-session/2026-04-12]
 
-### Feedback & Status Components
+#### Feedback & Status Components
 
 Must: Replace legacy `@/components/ui/feedback` imports with DS equivalents when touching a file during migration. The legacy module is a shadow of DS feedback primitives and must be emptied over the course of the migration. [source:phase-2/lane-2.0 review, 2026-04-23]
 
@@ -44,27 +54,27 @@ Never: Leave a legacy `@/components/ui/feedback` import in any file being migrat
 
 ---
 
-## Styling
+### Styling
 
-### Tokens
+#### Tokens
 
 Must: Use DS semantic color tokens for all color values — `text-foreground`, `bg-surface`, `border-brand-primary`, etc. Never use raw hex values, raw OKLCH, or Tailwind's default color palette (`text-gray-500`). [source:DS_CONSTRAINTS.md/colors]
 Must: Use `type-*` semantic utility classes for all typography — never compose raw Tailwind utilities (`text-base font-normal leading-relaxed`). [source:DS_CONSTRAINTS.md/typography]
 Must: Pair an explicit color token with every `type-*` class — `type-*` classes do not set color. [source:DS_CONSTRAINTS.md/typography]
 Never: Import font loaders directly from the client (e.g. `@/utils/fonts/textFonts` — `sejongHospitalBold`, `sejongHospitalLight`, `arial`, `heebo`, `montserrat`) and apply `.className` to elements. Font families are owned by the DS: `@font-face` + `--font-sejong-*` / `--font-pretendard` CSS variables are declared in `dist/styles.css`'s `@theme` block and consumed exclusively via `type-*` tokens (`type-h1`/`type-display` → Sejong Bold; `type-h2`/`type-h3`/`type-body*`/`type-label`/`type-caption` → Pretendard). The only legitimate direct use of `next/font/local` is at the app root for preloading/optimization (see "Font Loading (Next.js)" above) — not inline on component elements. During migration, strip any `sejongHospital*.className` / `heebo.className` / `montserrat.className` imports from lane files as you touch them. [source:client#80 Phase 1.2 review, 2026-04-21]
 
-### Class Utilities
+#### Class Utilities
 
 Must: Use `cn()` from `@umichkisa-ds/web` for all class merging — not raw `clsx`, `classnames`, or string concatenation. [source:DS_CODEBASE.md/utilities]
 Never: Use arbitrary Tailwind values (`px-[24px]`, `text-[#00274C]`, `mt-[13px]`). All spacing must come from Tailwind's built-in scale; all colors must come from DS semantic tokens. [source:DS_CONSTRAINTS.md/layout]
 
-### CSS Files
+#### CSS Files
 
 Never: Create new CSS modules or `.css` files for migrated components — use Tailwind utility classes with DS tokens. [source:grill-session/2026-04-12]
 
 ---
 
-## Icons
+### Icons
 
 Must: Use `<Icon name="...">` from `@umichkisa-ds/web` for all icons. [source:DS_CONSTRAINTS.md/iconography]
 Never: Import from `react-icons` — fully replaced by the DS icon system. [source:DS_CONSTRAINTS.md/iconography]
@@ -74,7 +84,7 @@ Must: Use the `size` prop from the 5-step scale (`xs`/`sm`/`md`/`lg`/`xl`) — n
 
 ---
 
-## Forms
+### Forms
 
 Must: Use `Form.*` compound fields from `@umichkisa-ds/form` for all form controls (`Form.Input`, `Form.Textarea`, `Form.Select`, `Form.Checkbox`, `Form.Radio`, `Form.Switch`, `Form.Button`). [source:DS_CODEBASE.md/form-wiring]
 Must: Use `useForm` from `@umichkisa-ds/form` to initialize form state — not `useForm` from `react-hook-form` directly. [source:DS_CODEBASE.md/form-wiring]
@@ -86,7 +96,7 @@ _Note: Validation strategy (zod + RHF resolver vs. RHF-native rules) is deferred
 
 ---
 
-## Layout
+### Layout
 
 Must: Use `Container` from `@umichkisa-ds/web` for the page shell pattern — never manually compose `mx-auto w-full max-w-screen-2xl px-4 md:px-6 lg:px-8`. [source:DS_CONSTRAINTS.md/layout]
 Never: Nest `Container` components — each page region gets one `Container` at most. [source:DS_CONSTRAINTS.md/layout]
@@ -95,9 +105,9 @@ Must: Use only the three layout breakpoint tiers — default (mobile), `md:` (>=
 
 ---
 
-## Local Components
+### Local Components
 
-### Decision Tree
+#### Decision Tree
 
 A component **stays local** in the client app if ANY of these are true:
 - It contains business logic (API calls, app state, routing)
@@ -111,13 +121,13 @@ A component **should be in DS** if ALL of these are true:
 
 [source:grill-session/2026-04-12, HARNESS_DESIGN.md/missing-ds-components]
 
-### Styling Rules for Local Components
+#### Styling Rules for Local Components
 
 Must: Local components follow the same DS token and styling rules as everything else — semantic colors, `type-*` classes, spacing tiers, `cn()` for class merging. Being local is not an excuse for raw utilities. [source:grill-session/2026-04-12]
 
 ---
 
-## className Passthrough
+### className Passthrough
 
 Prefer: Only pass layout and positioning classes via `className` on DS components — `mt-4`, `w-full`, `flex-1`, `hidden md:block`, etc. [source:grill-session/2026-04-12]
 Avoid: Overriding DS component internals via `className` (padding, font-size, color, border-radius). Frequent overrides signal that the DS component needs a new variant — collect these for DS fixes. [source:grill-session/2026-04-12]
@@ -125,7 +135,7 @@ Exception: When an app-specific override is genuinely necessary, add a comment e
 
 ---
 
-## Third-Party Libraries
+### Third-Party Libraries
 
 Never: Import from `@radix-ui/*` directly for UI that DS already provides (Dialog, Dropdown, Popover, Accordion, etc.) — DS wraps Radix internally. [source:grill-session/2026-04-12]
 Never: Import from NextUI or HeroUI — fully replaced by DS. [source:grill-session/2026-04-12]
@@ -134,7 +144,7 @@ Exception: Domain-specific libraries with no DS equivalent (`@fullcalendar/react
 
 ---
 
-## Migration-Specific
+### Migration-Specific
 
 _Temporary rules for the client migration (Phases 0–5). Remove this section post-migration._
 

--- a/docs/DS_CLIENT_USAGE.md
+++ b/docs/DS_CLIENT_USAGE.md
@@ -79,6 +79,27 @@ Before writing any spacing / color / radius / text / icon-size value, identify i
 - 5-step scale: `xs` / `sm` / `md` / `lg` / `xl`
 - Never override with font-size utilities or arbitrary CSS.
 
+### "What to Use" Rules (Must)
+
+A condensed, write-time view of the Must rules from Part 2. Read Part 2 for full context and source citations.
+
+- Use `Container` for page shells. Never compose `mx-auto max-w-screen-2xl px-4 ...` manually.
+- Use `Form.*` compounds + `useForm` from `@umichkisa-ds/form` for all forms. Never `useState` for form state.
+- Use `<Icon name="..." />` from `@umichkisa-ds/web` for all icons. Never `react-icons`, never direct `lucide-react`, never inline SVGs.
+- Use `cn()` from `@umichkisa-ds/web` for all className merging. Never raw `clsx` or string concatenation.
+- Use `StatusView` (variants + `fullScreen` prop) for full-page status. Never `<div className="h-screen flex items-center">` wrappers.
+- Use semantic Badge / Alert variants for status content (`success`, `warning`, `error`, `info`). Never `outline` for status.
+- Use breakpoints `default` / `md:` / `lg:` only. Never `sm:`, `xl:`, `2xl:`.
+- Use `type-*` classes paired with a color token. Never override with `!font-*`.
+- Cap inner content with `max-h-[…]` if a DS layout component (Dialog, Tabs, Form, Card) doesn't fit. Never apply `flex` / `overflow-*` to the DS component to force fill.
+
+### Visibility & Hierarchy Rules
+
+- **`text-muted-foreground` is NOT default body color.** Reserve for *genuinely secondary* content (captions, helper text, metadata, timestamps). Card values, list labels, body paragraphs, form labels stay `text-foreground`. [source:MEMORY/feedback]
+- **Intro paragraphs are primary content.** A page's lead paragraph or section intro is `text-foreground`, not muted. [source:MEMORY/feedback_intro_foreground]
+- **No left-border accent for selected state.** Use `bg-brand-accent-subtle border-brand-primary` (full border ring), not a `border-l-4` accent stripe. [source:MEMORY/feedback_no_left_border]
+- **No padding override on Card / CardContent / CardFooter.** Respect component defaults. If padding feels wrong, the Card is being misused for a non-card surface — pick a different DS component. [source:MEMORY/feedback_card_no_override]
+
 ---
 
 ## Part 2 — Review-Time Rulebook

--- a/docs/DS_CLIENT_USAGE.md
+++ b/docs/DS_CLIENT_USAGE.md
@@ -10,6 +10,75 @@ _For author-side rules (building DS components), see `DS_CONSTRAINTS.md`._
 
 _Read this BEFORE writing any line of client code that touches UI. Implementers: this is your write-time cheat sheet. Reviewers: skip to Part 2 — Review-Time Rulebook below._
 
+### Available DS Surface (quick-ref)
+
+For complete details, see `DS_CODEBASE.md`. This subset covers the surface most lanes need.
+
+**Components (`@umichkisa-ds/web`):**
+- Layout: `Container`, `Grid`, `Card` (+ `CardHeader`, `CardContent`, `CardFooter`, `CardTitle`, `CardDescription`)
+- Surfaces / overlays: `Dialog`, `Dropdown`, `Popover`, `Tooltip`
+- Inputs (raw — prefer `Form.*` from form package): `Button`, `IconButton`, `LinkButton`, `Badge`, `Avatar`
+- Feedback: `StatusView` (variants: `not-authorized`, `not-found`, `not-logged-in`, `error`, `loading`; `fullScreen` prop), `Alert` (variants: `success`, `warning`, `error`, `info`), `LoadingSpinner`, `Skeleton`
+- Navigation: `Tabs` (+ `TabsList`, `TabsTrigger`, `TabsContent`), `Accordion`, `Pagination`, `ToggleGroup`
+- Display: `Table` (+ `TableMobileList`), `Divider`
+- Date: `Calendar`, `DatePicker`, `DateRangePicker`
+- Toast: `Toaster` (mount once at root), `toast()` from `@umichkisa-ds/web`
+- Utilities: `cn()`, `Icon`, `OnlyMobileView`
+
+**Form components (`@umichkisa-ds/form`):**
+- Compounds: `Form.Input`, `Form.Textarea`, `Form.Select`, `Form.Checkbox`, `Form.Radio`, `Form.Switch`, `Form.Button`, `Form.DatePicker`, `Form.DateRangePicker`
+- Hooks: `useForm`, `useFormField`, `useFormStatus`, `useFormContext`
+
+**Token classes (Tailwind v4 @theme):**
+- Color: `text-foreground`, `text-muted-foreground`, `text-disabled-foreground`, `text-link`, `bg-surface`, `bg-surface-muted`, `bg-surface-subtle`, `bg-brand-primary`, `bg-brand-accent`, `bg-brand-accent-subtle`, `border-border`, `border-border-strong`, `border-brand-primary`, plus status: `bg-success`, `bg-warning`, `bg-error`, `bg-info` (and `*-subtle` variants)
+- Typography: `type-display`, `type-h1`, `type-h2`, `type-h3`, `type-body`, `type-body-sm`, `type-label`, `type-caption`
+- Spacing tiers: `gap-2` / `gap-4` / `gap-6` (Element / Component / Section)
+- Radius: `rounded-md`, `rounded-lg`, `rounded-full`
+- Breakpoints: default, `md:`, `lg:` only
+
+**Icons:**
+- `<Icon name="..." size="xs|sm|md|lg|xl" />` from `@umichkisa-ds/web`. Registry: `packages/web/src/components/icon/registry.ts`. If a name is missing, use `ds-fix-during-migration`.
+
+### Tier Picker (write-time check)
+
+Before writing any spacing / color / radius / text / icon-size value, identify its tier and pick the canonical token. If you cannot tier-justify a value, do not write it — flag it and ask.
+
+**Spacing (gap, padding, margin):**
+- Element tier (8px) → `gap-2`, `space-x-2`, `p-2` — icon+text, button+icon, tag clusters, inline groups
+- Component tier (16px) → `gap-4`, `space-y-4`, `p-4` — between sibling components inside a feature, list items, stacked form fields, card internals
+- Section tier (24px) → `gap-6`, `space-y-6`, `p-6` — between major page sections, page-level container padding
+- Off-tier (gap-3, gap-5, gap-7) → only inside a single component's internal layout (e.g., `p-3` on a chip is fine; `gap-3` between siblings is wrong)
+
+**Color (text):**
+- Primary content → `text-foreground` (body, labels users read, card values, headers)
+- Genuinely secondary → `text-muted-foreground` (captions, helper text, metadata, timestamps, placeholder hints)
+- Test: "if this text went to 40% opacity, would the screen still be usable?" If no, it's primary; keep `text-foreground`.
+
+**Color (background / border):**
+- Surfaces → `bg-surface` (cards), `bg-surface-subtle` (subtle blocks)
+- Brand → `bg-brand-primary`, `bg-brand-accent`, `bg-brand-accent-subtle`
+- Status (Badge/Alert) → `bg-success`, `bg-warning`, `bg-error`, `bg-info` (or use semantic variants on DS components)
+- Borders → `border-border` (default), `border-border-strong` (emphasized), `border-brand-primary` (brand emphasis)
+
+**Radius:**
+- `rounded-md` → buttons, inputs, cards (default DS)
+- `rounded-lg` → modals, larger surfaces
+- `rounded-full` → avatars, pills
+- `rounded-xl` / `rounded-2xl` → only with explicit DS-surface justification
+
+**Typography:**
+- Display / hero → `type-display`
+- Headings → `type-h1`, `type-h2`, `type-h3`
+- Body → `type-body` (default), `type-body-sm` (compact)
+- Labels → `type-label` (form labels, button labels)
+- Captions → `type-caption` (metadata, timestamps, fine print)
+- Always pair with a color token (`type-*` does not set color).
+- Never override weight with `!font-*` — pick a different `type-*` class.
+
+**Icon size:**
+- 5-step scale: `xs` / `sm` / `md` / `lg` / `xl`
+- Never override with font-size utilities or arbitrary CSS.
+
 ---
 
 ## Part 2 — Review-Time Rulebook

--- a/docs/DS_CLIENT_USAGE.md
+++ b/docs/DS_CLIENT_USAGE.md
@@ -95,10 +95,10 @@ A condensed, write-time view of the Must rules from Part 2. Read Part 2 for full
 
 ### Visibility & Hierarchy Rules
 
-- **`text-muted-foreground` is NOT default body color.** Reserve for *genuinely secondary* content (captions, helper text, metadata, timestamps). Card values, list labels, body paragraphs, form labels stay `text-foreground`. [source:MEMORY/feedback]
-- **Intro paragraphs are primary content.** A page's lead paragraph or section intro is `text-foreground`, not muted. [source:MEMORY/feedback_intro_foreground]
-- **No left-border accent for selected state.** Use `bg-brand-accent-subtle border-brand-primary` (full border ring), not a `border-l-4` accent stripe. [source:MEMORY/feedback_no_left_border]
-- **No padding override on Card / CardContent / CardFooter.** Respect component defaults. If padding feels wrong, the Card is being misused for a non-card surface — pick a different DS component. [source:MEMORY/feedback_card_no_override]
+- **`text-muted-foreground` is NOT default body color.** Reserve for *genuinely secondary* content (captions, helper text, metadata, timestamps). Card values, list labels, body paragraphs, form labels stay `text-foreground`. Test: "if this text went to 40% opacity, would the screen still be usable?" If no, it's primary.
+- **Intro paragraphs are primary content.** A page's lead paragraph or section intro is `text-foreground`, not muted.
+- **No left-border accent for selected state.** Use `bg-brand-accent-subtle border-brand-primary` (full border ring), not a `border-l-4` accent stripe.
+- **No padding override on Card / CardContent / CardFooter.** Respect component defaults. If padding feels wrong, the Card is being misused for a non-card surface — pick a different DS component.
 
 ---
 

--- a/docs/DS_CLIENT_USAGE.md
+++ b/docs/DS_CLIENT_USAGE.md
@@ -52,6 +52,16 @@ Mapping:
 
 Never: Leave a legacy `@/components/ui/feedback` import in any file being migrated in the current lane — swap it in-lane even if the lane's primary scope is different. The only exception is when the lane's issue explicitly lists the swap as a non-goal (e.g., a page-shell lane defers feedback migration to a later legacy-ui-swap lane). [source:phase-2/lane-2.0 review, 2026-04-23]
 
+#### Status Variant Selection (G2)
+
+Must: When a `Badge`, `Alert`, or other DS feedback component expresses status, use the **semantic** variant — `success`, `warning`, `error`, `info` — not the neutral/outline variant.
+
+Status content includes: "available now" / "즉시 제공" → `success`; "age check required" / "연령 확인" → `warning`; error states → `error`; passive informational → `info`.
+
+`outline` / default neutral is for non-status content (categorical tags, generic labels).
+
+[source:phase-2/lane-2.11b smoke fix, commit 59462d4]
+
 ---
 
 ### Styling
@@ -60,6 +70,9 @@ Never: Leave a legacy `@/components/ui/feedback` import in any file being migrat
 
 Must: Use DS semantic color tokens for all color values — `text-foreground`, `bg-surface`, `border-brand-primary`, etc. Never use raw hex values, raw OKLCH, or Tailwind's default color palette (`text-gray-500`). [source:DS_CONSTRAINTS.md/colors]
 Must: Use `type-*` semantic utility classes for all typography — never compose raw Tailwind utilities (`text-base font-normal leading-relaxed`). [source:DS_CONSTRAINTS.md/typography]
+Never: Override the weight of a `type-*` class with `!font-*` (e.g., `type-body !font-semibold`, `type-h2 !font-bold`). The `type-*` tier already bakes weight, font-family, and line-height. If a different weight is needed, pick a different `type-*` class — do not override. [source:MEMORY/feedback_type_weight_override; phase-2/lane-2.19 commit 09d2cd0 swept these out]
+
+Exception during migration: short-lived `!font-*` overrides may exist when the type-* tier doesn't yet expose the desired weight. Collect these as a DS gap (request a new `type-*` tier or a weight variant via `ds-fix-during-migration`); do not let them ship long-term.
 Must: Pair an explicit color token with every `type-*` class — `type-*` classes do not set color. [source:DS_CONSTRAINTS.md/typography]
 Never: Import font loaders directly from the client (e.g. `@/utils/fonts/textFonts` — `sejongHospitalBold`, `sejongHospitalLight`, `arial`, `heebo`, `montserrat`) and apply `.className` to elements. Font families are owned by the DS: `@font-face` + `--font-sejong-*` / `--font-pretendard` CSS variables are declared in `dist/styles.css`'s `@theme` block and consumed exclusively via `type-*` tokens (`type-h1`/`type-display` → Sejong Bold; `type-h2`/`type-h3`/`type-body*`/`type-label`/`type-caption` → Pretendard). The only legitimate direct use of `next/font/local` is at the app root for preloading/optimization (see "Font Loading (Next.js)" above) — not inline on component elements. During migration, strip any `sejongHospital*.className` / `heebo.className` / `montserrat.className` imports from lane files as you touch them. [source:client#80 Phase 1.2 review, 2026-04-21]
 
@@ -90,7 +103,9 @@ Must: Use `Form.*` compound fields from `@umichkisa-ds/form` for all form contro
 Must: Use `useForm` from `@umichkisa-ds/form` to initialize form state — not `useForm` from `react-hook-form` directly. [source:DS_CODEBASE.md/form-wiring]
 Never: Use native `useState` for form field values or validation state in migrated forms — all form state goes through `useForm`. [source:grill-session/2026-04-12]
 Prefer: `useFormField` escape hatch only for custom controls not covered by `Form.*` compounds. [source:DS_CODEBASE.md/form-wiring]
-Never: Import `react-hook-form` directly — always use `@umichkisa-ds/form` re-exports (`useForm`, `useFormField`, `useFormStatus`, `useFormContext`). [source:grill-session/2026-04-12]
+Never: Import any RHF symbol (`useForm`, `useFormField`, `useFormStatus`, `useFormContext`, `useFormState`, `useWatch`, `Controller`) directly from `react-hook-form`. Always use `@umichkisa-ds/form` re-exports. The DS form package wraps `useForm` with `mode: "onTouched"` and other defaults; bypassing the wrapper produces inconsistent validation timing and breaks the DS form contract.
+
+If a hook you need is not yet re-exported by `@umichkisa-ds/form`, treat it as a DS gap and run `ds-fix-during-migration` to add the re-export — do not import from `react-hook-form` as a workaround. [source:phase-2/lane-2.19 — `useFormContext` was missing from `@umichkisa-ds/form`; required form 1.0.1 re-export commit 086c148]
 
 _Note: Validation strategy (zod + RHF resolver vs. RHF-native rules) is deferred to Phase -1.7. Rules will be added here once resolved._
 
@@ -101,6 +116,14 @@ _Note: Validation strategy (zod + RHF resolver vs. RHF-native rules) is deferred
 Must: Use `Container` from `@umichkisa-ds/web` for the page shell pattern — never manually compose `mx-auto w-full max-w-screen-2xl px-4 md:px-6 lg:px-8`. [source:DS_CONSTRAINTS.md/layout]
 Never: Nest `Container` components — each page region gets one `Container` at most. [source:DS_CONSTRAINTS.md/layout]
 Must: Follow the three-tier vertical spacing system — Element (`gap-2` / 8px), Component (`gap-4` / 16px), Section (`gap-6` / 24px). [source:DS_CONSTRAINTS.md/layout]
+
+**Tier-justify every spacing value before writing.** Spacing inside a single component (image+text inside a row, label+input inside a field, icon+text inside a chip) is **Component or Element tier** (`gap-2` / `gap-3` / `gap-4`), not Section tier. `gap-6`/`gap-8` are reserved for boundaries between major page sections. [source:phase-2/lane-2.11b smoke fix, commit 59462d4 — `gap-6` → `gap-4` correction on row internals]
+
+Write-time check (when picking a `gap-*` / `space-*` value):
+1. What is the role of the container? (page section / component-internal / inline)
+2. Is the chosen value the canonical tier value for that role? (8 / 16 / 24 px = `gap-2` / `gap-4` / `gap-6`)
+3. If you cannot answer (1) and (2) cleanly, do not write the value — ask.
+
 Must: Use only the three layout breakpoint tiers — default (mobile), `md:` (>= 768px), `lg:` (>= 1024px). Never use `sm:`, `xl:`, or `2xl:`. [source:DS_CONSTRAINTS.md/layout]
 
 ---
@@ -132,6 +155,26 @@ Must: Local components follow the same DS token and styling rules as everything 
 Prefer: Only pass layout and positioning classes via `className` on DS components — `mt-4`, `w-full`, `flex-1`, `hidden md:block`, etc. [source:grill-session/2026-04-12]
 Avoid: Overriding DS component internals via `className` (padding, font-size, color, border-radius). Frequent overrides signal that the DS component needs a new variant — collect these for DS fixes. [source:grill-session/2026-04-12]
 Exception: When an app-specific override is genuinely necessary, add a comment explaining why. [source:grill-session/2026-04-12]
+
+---
+
+### DS Component Layout — Do Not Override (G1)
+
+Never: Add flex / overflow / height / max-height utility classes to a DS layout component (`Dialog`, `DialogContent`, `Tabs`, `TabsList`, `TabsContent`, `Form`, `Card`, `CardContent`, `CardFooter`, `Sheet`, `Drawer`) to force size or layout. The DS owns the layout pattern of these components — flex containers, gap spacing, overflow behavior. Adding `flex flex-1 overflow-hidden` to `<Tabs>` or `<Form>` to make them fill height is fighting the DS. [source:phase-2/lane-2.11b smoke fix, commit c4cea05]
+
+If a layout doesn't fit:
+- Cap inner content with `max-h-[60vh]` (or similar) on the inner content child (e.g., `<TabsContent>`), not on the outer DS layout component
+- If the cap doesn't solve it, the DS component is missing a variant — collect via `ds-fix-during-migration`
+
+Allowed (positioning passthrough): `mt-4`, `w-full`, `mx-auto`, `hidden md:block` on DS components — these are layout/positioning, not internal layout overrides.
+
+Disallowed examples (would have been caught here in Phase 2):
+- `<Tabs className="flex flex-1 flex-col overflow-hidden">` — overrides DS Tabs layout
+- `<Form className="flex flex-1 flex-col gap-4 overflow-hidden">` — overrides DS Form layout
+- `<DialogContent className="max-h-[90dvh] flex flex-col">` — DS Dialog now owns this; override is redundant
+
+Allowed:
+- `<TabsContent className="max-h-[60vh] overflow-y-auto">` — height cap on inner content, not on DS layout
 
 ---
 

--- a/docs/DS_CODEBASE.md
+++ b/docs/DS_CODEBASE.md
@@ -1,5 +1,12 @@
 # DS_CODEBASE.md — Consumer Quick-Reference
 
+> **Implementers, read `docs/DS_CLIENT_USAGE.md` instead.** This doc is the
+> human-facing DS surface catalog used during planning / grill / discovery —
+> not the write-time enforcement doc. The `ds-client-review` agent and the
+> implementer subagent both read `DS_CLIENT_USAGE.md`, which has a Part 1
+> ("Available DS Surface" + tier picker + write-time rules) curated for
+> implementers and a Part 2 (full constraint rulebook) for the reviewer.
+
 Lookup table for AI agents consuming `@umichkisa-ds` in client apps. For each component: **when** to use it and **where** to read the full API. Read the source file before using any component.
 
 > Author-side DS internals (token tiers, font pipeline, docs infrastructure) → `docs/DS_AUTHORING.md`

--- a/docs/history/migrating-the-client.md
+++ b/docs/history/migrating-the-client.md
@@ -1,0 +1,453 @@
+# Migrating the Client to the Design System
+
+A retrospective on phases -1 → 2 of the ds-client-migration project, and on the
+harness rebuild that landed immediately before Phase 3 (PR #12 on
+`umichkisa-ds`). This is the third entry in the series. The first two —
+[Building umichkisa-ds from Scratch](building-the-design-system.md) and
+[Auditing the Docs App](auditing-the-docs.md) — covered the design system
+itself. This one covers what happened when I pointed it at its first real
+consumer.
+
+## Context
+
+KISA's main website (`KISA-website/client`) is a Next.js 15 App Router app
+that predates the design system. It has five sub-apps under one repo, all
+under `umichkisa.com`:
+
+| # | App | Route | Viewport |
+|---|---|---|---|
+| 1 | kisa-web | `/` | Desktop-first, responsive |
+| 2 | jobs-curator | `/jobs` | Responsive |
+| 3 | pocha-userfacing | `/pocha` | Mobile-only |
+| 4 | pocha-dashboard | `/pocha/dashboard` | Desktop + tablet |
+| 5 | pocha-manage | `/pocha/manage` | Desktop + tablet |
+
+The pre-migration state: hand-rolled UI components scattered across the
+client, no shared tokens, no constraint enforcement, no docs. The design
+system existed; the client didn't know it existed.
+
+The same lived constraints from the previous phases held — Korean Army
+service, off-duty hours, VSCode tunnel from the unit. By Phase 2 these
+constraints were no longer noteworthy; they were just the operating
+environment.
+
+## Timeline
+
+- **Start:** 2026-04-12 (Phase -1.0, harness bootstrap)
+- **Pre-Phase-3 cut:** 2026-04-25 (PR #12 merged)
+- **Duration so far:** ~13 active days
+- **Phases shipped:** -1 (bootstrap), 0, 0.5, 1 (jobs-curator), 2 (pocha-manage)
+- **Phases remaining:** 3 (pocha-dashboard), 4 (pocha-userfacing), 5 (kisa-web)
+- **Client commits in window:** ~56
+- **DS patch releases driven by migration evidence:** 19 (`@umichkisa-ds/web 1.0.1 → 1.0.20`, `@umichkisa-ds/form 1.0.0 → 1.0.1`)
+- **DS new components introduced mid-migration:** 1 (`FileUpload`)
+
+## The Shape of the Migration
+
+**Hybrid slicing.** Phases 0 and 0.5 are horizontal singletons (Tailwind
+v4 install, MSW, test framework, shared Header/Footer). Phases 1–5 are
+vertical, one feature-app at a time, with subphases enumerated at each
+phase's kickoff — never up front.
+
+A subphase is a *lane* — a single feature, page, or refactor with its own
+audit row, plan task, branch, and PR (or direct push, in interactive
+mode). Lanes are the unit of parallelism, the unit of review, and the
+unit of merge. Phase 2 alone ran 22 lanes.
+
+**Vertical slicing of features over horizontal slicing of layers.** This
+was an explicit early decision and it kept paying off. A vertical lane
+has a working before-and-after, a deployable preview URL, and a clean
+surface to grill against. A horizontal lane (e.g. "swap all Buttons
+everywhere") would have meant 5 apps' worth of regression risk per merge.
+
+## Phase -1 — Bootstrapping the Harness
+
+Six subphases of pure setup before any client code was touched. Mirrors
+the Phase 2 of the component build (workflow before code), and was the
+single highest-leverage stretch of the migration.
+
+The artifacts that landed in -1:
+
+| Artifact | What | Role |
+|---|---|---|
+| `docs/DS_CLIENT_USAGE.md` | Constraint doc *for consumers of the DS* | Migration analogue of `DS_CONSTRAINTS.md` |
+| `ds-client-review` agent | Reviews changed `.tsx` against `DS_CLIENT_USAGE.md` | Migration analogue of `ds-review` |
+| `ds-client-constrained-execution` skill | Per-task gate: implementer → review → typecheck → commit | Migration analogue of `ds-constrained-execution` |
+| `ds-fix-during-migration` skill | When a DS bug surfaces from a lane, this is the path | "DS is its own customer" |
+| `ds-phase-end-bump` skill | Accumulator-bump-publish-relink at phase end | Release management |
+| `client/scripts/link-ds.sh` + `unlink-ds.sh` | Local symlink swap so client consumes WIP DS without registry roundtrip | Tunnel-friendly dev loop |
+| `HARNESS_DESIGN.md` + `AUTONOMOUS_PROTOCOL.md` | The rules of how a phase runs | Locked through grill on 2026-04-12 |
+
+The grill that locked Phase -1 was where I committed to:
+
+- Worktrees off `dev` per lane, mocks-on Vercel preview on `dev`
+- MSW (write endpoints only), committed, env-gated
+- DS pinned strictly (no `^`) in client `package.json`; DS fixes batched per phase, bump once at phase end (with a blocking-fix exception that I underestimated)
+- DS form package resolver-agnostic; no zod
+- Local workarounds for missing DS components, add to DS later (not blocking)
+
+`DS_CLIENT_USAGE.md` started smaller than `DS_CONSTRAINTS.md` — only ~144
+lines and only review-shaped. It said "here are the rules; the reviewer
+checks them." It did not yet know that consumers were going to need a
+*write-time* version of the same rules. That gap would not surface until
+Phase 2.
+
+## Phases 0 and 0.5 — First Contact With Reality
+
+Phase 0 was Tailwind v4 install + DS install + MSW + test framework + tunnel
+settings. Phase 0.5 was the shared Header/Footer/MobileMenu. Both are
+horizontal singletons, no subphases, intentionally smaller surface area than
+the vertical phases that follow.
+
+Two things happened that shaped everything downstream.
+
+**The radix-bundle catastrophe (Phase 1.1).** Client `next build` failed
+with `Module not found` for `@radix-ui/number`, `react-presence`,
+`react-use-previous`, etc. pnpm's symlinked transitives are not
+npm-client-resolvable — the DS was published assuming the consumer
+would also be on pnpm. Fix: tsup `noExternal` to bundle radix transitives
+into `dist/index.js`. Released as `1.0.4` mid-phase.
+
+This was the first **mid-phase bump**, and the first datapoint that the
+"DS fixes batch at phase end" rule from -1 was wrong. Phase 0.5 had
+already discovered the pattern (`instagram-brand` icon needed for
+Footer's lane 0.5.5 → mid-phase patch `1.0.1`); Phase 1.1 made it
+unignorable. By the end of Phase 2 the doctrine was inverted:
+**mid-phase patch is the default; phase-end batching is the
+exception that has not happened yet.**
+
+**Vercel preview as the verification surface.** Locally on the tunnel,
+everything was best-effort. Mocks-on Vercel preview on the `dev` branch
+became the canonical "does this actually work" answer. Every PR's "test
+plan" pointed at a preview URL. This shape held for the entire
+migration so far.
+
+## Phase 1 — jobs-curator (the autonomous lane proves itself)
+
+11 lanes, all merged, no manual interventions beyond the standard
+checkpoints. Closed with DS at `1.0.8` and zero phase-end DS fixes —
+every fix had been mid-phase-shipped.
+
+What worked:
+
+- **Lane = MSW handlers as the first task.** Lane 1.1 was MSW handlers for the jobs API. Once that landed, every downstream UI lane consumed mocked data instead of waiting on backend. This pattern repeated in every vertical phase since.
+- **Worktree per lane, autonomous PR per lane.** Each lane was its own branch off `dev`, its own PR, its own ds-client-review pass, its own typecheck. PRs reviewed in batches of 3–4.
+- **Redesign-over-preserve was vindicated.** Lane 1.4 (TagList → inline segmented + DateRangePicker) and Lane 1.5 (JobPostingGrid + Card) both threw out the existing visual treatment entirely. Pre-migration concern was that this would balloon scope. It didn't, because the brand-identity envelope (navy + maize + Korean type, page structure, signature moves) is small and the rest is replaceable. Phase 2 would later codify this as a feedback memory.
+
+What I learned:
+
+- **Hooks/context drift across lanes is real.** Lane 1.8 was a dedicated hooks/context cleanup lane — work that had accumulated as small TODOs across lanes 1.1–1.7. From Phase 2 onward, this became a standing "audit-after redesign pass" lane at the end of every vertical phase.
+- **`ds-client-review` was not catching everything.** It caught DS misuse — wrong components, wrong tokens, wrong tier. It didn't catch *code-quality* issues at the React layer: components with too many responsibilities, ad-hoc state machines that should have been declarative, duplicated logic across siblings. This was a known gap. Phase 1 deferred filling it.
+
+## Phase 2 — pocha-manage (the stress test)
+
+22 lanes, the largest and most heterogeneous phase so far. Where Phase 1
+proved the autonomous flow, Phase 2 stress-tested every part of the
+harness simultaneously. This is the phase that produced the evidence PR
+#12 would later bake into write-time enforcement.
+
+### Modes emerged
+
+The harness had been written in Phase -1 with a single execution shape:
+"work the lane in a worktree, open a PR." Phase 2 fragmented that
+single shape into five distinct modes that needed five different
+session affordances:
+
+| Mode | Trigger | Shape |
+|---|---|---|
+| **A** | Phase folder lacks `audit.md` | Audit writing — read app state, classify lanes, output `audit.md` |
+| **B** | `audit.md` present, `plan.md` missing | Plan writing + GH issue generation per lane |
+| **C1** | Sitting PR, CI green, no `needs-decision` | PR review (skim-and-merge) |
+| **C2** | Sitting PR with `needs-decision` / `needs-interactive` | PR review (live review against the running app) |
+| **D** | Open `needs-interactive` issue with no PR | Interactive execution — me driving, agent assisting |
+| **E** | All lanes merged | Phase close-out, end-bump if needed |
+
+The hard separation between **C (PR review)** and **D (interactive
+execution)** turned out to be load-bearing. C runs in the main client
+clone (auto-checkout the PR branch); D runs in a nested worktree at
+`client/.worktrees/<lane-id>/` off `origin/dev`. The split exists so
+that a parallel terminal doing Mode C against PR #109 cannot collide
+with another terminal doing Mode D on lane 2.19. Without the split, two
+terminals fighting over the working tree was a real failure mode I hit
+twice before it got codified.
+
+### Interactive vs autonomous
+
+The other axis the harness had to add: **autonomous lanes ship a PR;
+interactive lanes ship a direct push to `dev`**. Interactive lanes are
+ones I drive in real-time — usually because the work involves UX
+judgement that can't be encoded into the implementer agent's prompt. PRs
+exist as a review surface for autonomous work. Driving a lane live and
+*then* opening a PR against my own keystrokes is theater.
+
+The corollary: **issues exist for every lane, autonomous or not** —
+they're created at plan-writing time, before the mode split. The "Mode
+D = no PR" rule does NOT extend to "Mode D = no issue." That distinction
+is small but it broke wrap-up flow twice before becoming a feedback
+memory.
+
+### The DS-as-its-own-customer feedback loop
+
+19 patch releases of `@umichkisa-ds/web` were driven by Phase 2 evidence
+(plus a couple from Phase 0.5/1). Each one followed the same pattern:
+
+1. Lane is mid-execution
+2. Implementer hits a DS gap — missing variant, missing prop, missing component, broken default
+3. `ds-fix-during-migration` skill takes over: fix in DS repo, patch-bump, publish, re-link in client
+4. Lane resumes against the new DS version
+5. Entry appended to `ds-fixes-log.md`
+
+The 19 entries trace out a real audit of the DS surface area against a
+real consumer. A few were component additions (`FileUpload` —
+`1.0.9`, full new form primitive with 27 tests, surfaced from lane
+2.4); a few were one-line fixes (`Input min-w-0` for native time
+inputs in flex containers, `1.0.18`); one was a four-release saga (the
+Toaster z-index / outer-section / sonner-CSS interaction across
+`1.0.10` through `1.0.12`).
+
+The Toaster saga is the one I want to remember. The bug was: empty `<section>`
+flowed in document order on every Toaster-mounted page, adding a tall blank
+box. Fix attempt 1 (`1.0.10`): import sonner CSS. Wrong cause — sonner
+self-injects. Fix attempt 2 (`1.0.11`): position the outer section. Created a
+new stacking context but no `z-index`. Fix attempt 3 (`1.0.12`): add
+`z-index`. Three releases for one bug, all caught between client production
+and the docs app, all mid-phase. Without the mid-phase bump-default policy,
+the migration would have stalled here for a day each time.
+
+The lesson the log encodes: **the design system can only know its own gaps
+when a real consumer drives it through a real surface area.** The client
+migration *was* that drive. The DS came out of Phase 2 strictly better
+than it went in — same outcome as the audit phase, but the rule flow ran
+through a different artifact (`ds-fixes-log.md` instead of
+`DS_CONSTRAINTS.md`).
+
+### Rules mined from Phase 2
+
+By the end of Phase 2 there were five recurring corrections that the
+`ds-client-review` agent kept making across lanes. They were not in
+`DS_CLIENT_USAGE.md`. They were trapped in the agent's running context
+and in scattered feedback memories:
+
+| ID | Rule | Origin |
+|---|---|---|
+| **G1** | No override on DS layout components (`flex`, `overflow`, `height`) | Lane 2.11b smoke fix (commit c4cea05) |
+| **G2** | Status variant selection — semantic, not outline | Lane 2.11b |
+| **G3** | Spacing tier write-time check — `gap-6` is not component-internal | Lane 2.11b |
+| **G4** | Form hooks import path — never bypass `@umichkisa-ds/form` | Lane 2.19 |
+| **G5** | `type-*` weight override prohibition (the `type-*` classes set their own weight) | MEMORY rule, lane 2.19 sweep |
+
+These were Tier-2-shaped rules, in the audit-phase taxonomy: bulk
+patterns the system kept catching but the rulebook didn't yet name. The
+question PR #12 would ask: do they belong in the rulebook, and if so,
+write-time or review-time?
+
+## PR #12 — The Pre-Phase-3 Tighten
+
+After Phase 2 closed and before Phase 3 (pocha-dashboard) audit kicked
+off, I stopped the migration and spent a session grilling out exactly
+what the harness had outgrown. The output was
+`docs/plans/2026-04-25-harness-improvements.md` and the resulting PR is
+21 commits across 21 files (additions: 3880, deletions: 725). It made
+**zero client-side changes**. Everything was harness.
+
+### Why now
+
+The signal that pushed me to pause was uncomfortable: I had a list of
+~5 recurring corrections the review agent kept making (G1–G5), and the
+correct fix for "the review agent keeps catching X" is almost always
+"the implementer should not be writing X in the first place." The
+review agent is the safety net, not the loadbearer. If a class of
+violation recurs, the rulebook has an incomplete *write-time* face.
+
+`DS_CLIENT_USAGE.md` had been written entirely as a review document.
+It said "here is what to flag." It did not say "here is what to write."
+A write-time decision tree — Available DS Surface, Tier Picker, "What
+to Use" rules — would let the implementer tier-justify every value
+*before* writing code, instead of relying on a post-hoc reviewer to
+flag mistier'd `gap-6`s.
+
+### What changed
+
+**`DS_CLIENT_USAGE.md` split into Part 1 / Part 2.** Part 1 is the
+write-time decision tree (Available DS Surface, Tier Picker for
+spacing/color/radius/type/icon-size, "What to Use" Must rules,
+Visibility & Hierarchy rules absorbed from MEMORY). Part 2 is the
+existing review rulebook, end-to-end, plus G1–G5 baked from Phase 2
+evidence and the MEMORY-only rules promoted in (text-muted-foreground
+visibility, intro foreground, no-left-border, no-card-padding-override).
+144 lines → 287 lines.
+
+**`ds-client-review` agent now reads `DS_CLIENT_USAGE.md` itself.**
+Previously the orchestrating skill pasted the whole doc inline on every
+agent invocation. Cuts ~3K tokens per review round in the parent
+context. Agent runs in its own sub-context and reads the doc fresh
+each invocation.
+
+**New `toss-fe-review` agent.** This was the answer to Phase 1's "DS
+review doesn't catch code-quality issues." Per-task review against the
+four Toss Frontend Fundamentals axes (readability, predictability,
+cohesion, coupling) with a conservative `BLOCK / SUGGEST / INFO`
+severity gate. Wired between `ds-client-review` and typecheck. Conservative
+defaults — `BLOCK` only on real correctness/structure problems,
+`SUGGEST/INFO` collected for the PR body — so the gate doesn't
+over-refactor in autonomous loops. Two-round hard stop if `BLOCK`
+recurs.
+
+**New `review-ui-on-browser` skill.** Standalone, *manually invoked*,
+Playwright-CLI-based. Takes a running dev server URL + routes + viewports
+and produces a UI/UX rubric review (hierarchy, spacing rhythm, primary
+action visibility, state coverage, content readability). Originally
+designed to run inside the autonomous routine; that didn't survive
+contact with reality — Vercel free-tier preview auth + dev-only branch
+made per-PR Playwright runs impractical. So it lives outside the
+routine, invoked during PR review or before merging an interactive
+lane. Initially built around the Playwright Node API; rewritten near
+the end of the PR to use Microsoft's `@playwright/cli` skill instead.
+
+**`AUTONOMOUS_PROTOCOL.md` restructured.** 739 → 362 lines. Mode C
+split into C1 (ready-to-merge) and C2 (interactive review). Mode D
+explicitly placed in a nested worktree off `dev` for parallel-terminal
+safety. New §3.1 (feedback-during-review: default fix on branch, defer
+to new lane on scope/DS/feature drift) and §3.2 (parallel-terminal
+safety). Old preflight-style intro retired; doc is now consult-on-demand.
+
+**`CLAUDE.md` preflight trimmed.** Old: TODO → HARNESS_DESIGN (full)
+→ symlink check → DS_CODEBASE. New: TODO → symlink check. Mode-detection
+table inlined at the top in tabular form so the cold session can route
+into a mode without preloading the protocol doc. Each mode lazy-loads
+only what it needs. Saves ~40K tokens of cold-session context.
+
+### What it looks like, end-to-end
+
+A Phase 3 NO-TDD lane will now run:
+
+```
+implementer (with Part 1 tier-justification pre-flight) →
+  ds-client-review (reads its own ruleset) →
+  toss-fe-review (4-axis quality gate) →
+  typecheck →
+  commit
+```
+
+A TDD lane:
+
+```
+test-writer (red) →
+  implementer (green) →
+  ds-client-review →
+  toss-fe-review →
+  tests-green-verify →
+  refactor →
+  typecheck →
+  commit
+```
+
+End of feature: `vercel-react-best-practices` final pass. Manual
+`review-ui-on-browser` before merge for any UI-touching lane.
+
+## What Made It Work
+
+### 1. Phase -1 was non-negotiable
+Six subphases of pure harness setup before touching any client code. Same
+shape as the design-system project's "process before code" stretch. The
+mid-phase course corrections (mid-phase bump default, Mode C/D split,
+G1–G5 baking) were all *adjustments* to a working harness. None of them
+required scrapping the harness. That's only possible because the
+foundation was right.
+
+### 2. The DS feedback loop was structural, not improvised
+`ds-fix-during-migration` was a Phase -1 skill, not an emergency response.
+When the implementer hit a DS gap on Lane 1.1 the path was already there:
+fix in DS, patch-bump, re-link, resume. No "should we fix the DS or work
+around it" debate per occurrence. The 19 patch releases happened because
+the path was so cheap that the *workaround* would have been more expensive.
+
+### 3. Mode-based session routing
+The five modes were not in the original Phase -1 design — they emerged
+across Phases 0.5 → 2 as the work fragmented. Naming them and writing
+their detection signals into `CLAUDE.md` turned cold-session pickup from
+"read everything, figure out where I am" into "look at the table, route,
+load the mode-specific docs." This was the highest single-PR throughput
+improvement the harness has gotten.
+
+### 4. PR #12 happened *before* Phase 3, not during it
+The instinct on a deadline is to keep shipping. Phase 2 ended with five
+recurring violations the rulebook didn't name and a code-quality gap the
+review chain didn't cover. Continuing into Phase 3 with that state would
+have meant Phase 3's lanes catching the same five issues in PR review
+again. Stopping for one harness PR before the next phase's audit was the
+right call. (It was also, not coincidentally, the same shape as the
+design system's audit phase pausing to write `review-docs-app-ui` before
+running it across 62 pages.)
+
+### 5. Vertical slicing kept the blast radius bounded
+Every lane shipped or didn't ship one feature. No lane ever broke a
+feature it wasn't touching. When the Toaster z-index saga ran for three
+releases, the only consumers affected were the lanes that mounted
+`<Toaster />`. The other 18 lanes of Phase 2 kept moving in parallel.
+
+## What Didn't Work
+
+### 1. The "DS fixes batch at phase end" rule was wrong from day 1
+Phase -1 locked it. Phase 0.5 broke it. By Phase 2 the doctrine was
+inverted: mid-phase patch is the default. The phase-end accumulator
+exists, but in 19 mid-phase bumps and zero phase-end bumps so far it has
+never been used. The rule that survived was the *opposite* of the rule
+that was locked. Lock decisions when the cost of being wrong is small,
+not when the cost of being right is small.
+
+### 2. `DS_CLIENT_USAGE.md` was review-only for too long
+The doc was written as a reviewer's reference and stayed that way for
+eight phases. If it had been split into Part 1 (write) / Part 2 (review)
+in -1.2, several of the recurring G1–G5 violations would never have
+shipped to `ds-client-review` at all. Lesson: **a constraint document
+needs both a write-time and a review-time face from the start. They are
+not the same document.** The review-time face is exhaustive; the
+write-time face is a decision tree. Mixing them produces a doc that's
+too dense to consult before writing and too light to enforce after.
+
+### 3. `review-ui-on-browser` couldn't be wired into the routine
+The plan was for visual UI review to be one of the autonomous gates.
+Vercel preview auth + dev-only branch + free-tier rate limits killed
+that idea. The skill exists, manual-only, and is exercised case by case.
+This is the audit-phase Chrome-MCP-hard-gate problem in a different
+costume: the spec assumed an ideal infrastructure that the operating
+environment does not provide.
+
+### 4. The first `review-ui-on-browser` build was wrong
+Initially built against Playwright Node API + `npx playwright`. Wasn't
+discovered to be wrong until late in the PR; rewritten in the final
+commits to use the `@playwright/cli` sibling skill instead. Cost: a few
+commits of churn. Lesson: the skill ecosystem has primitives for things
+like this. Search before authoring.
+
+## By the Numbers
+
+| Metric | Value |
+|--------|-------|
+| Window | 2026-04-12 → 2026-04-25 (13 active days) |
+| Phases shipped | -1 (bootstrap), 0, 0.5, 1, 2 |
+| Phases remaining | 3, 4, 5 |
+| Lanes (Phase 1 + 2) | 11 + 22 = 33 |
+| Client commits in window | ~56 |
+| DS patch releases driven by migration | 19 |
+| New DS components introduced mid-migration | 1 (`FileUpload`) |
+| New skills (migration-side) | 5 (`ds-client-constrained-execution`, `ds-fix-during-migration`, `ds-phase-end-bump`, `wrapping-up-pr`, `review-pr-queue`) + 1 manual (`review-ui-on-browser`) |
+| New agents (migration-side) | 2 (`ds-client-review`, `toss-fe-review`) |
+| Modes the harness routes between | 5 (A, B, C1/C2, D, E) |
+| `DS_CLIENT_USAGE.md` size | 144 → 287 lines |
+| `AUTONOMOUS_PROTOCOL.md` size | 739 → 362 lines |
+| Cold-session preflight context savings (PR #12) | ~40K tokens |
+| `ds-client-review`-per-round inline-paste savings (PR #12) | ~3K tokens |
+| Model | Claude Opus 4.6 (1M context) → Opus 4.7 mid-Phase-2 |
+
+---
+
+The component phase built the system. The audit phase made the system
+document itself. The migration phase made the system *document itself in
+terms of how its consumers use it*. PR #12 was the moment that the
+system's "how to consume me" face caught up with the system's "how to
+build me" face — same shape, same disciplines, same write/review split,
+finally articulated. Phase 3 starts with the rulebook tighter than the
+client code that will be written against it. That's the right
+asymmetry.

--- a/docs/plans/2026-04-25-harness-improvements.md
+++ b/docs/plans/2026-04-25-harness-improvements.md
@@ -1,0 +1,1385 @@
+# Harness + ds-client-constrained-execution Improvements
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Tighten the ds-client-migration harness before Phase 3 — fix doc/agent token plumbing, bake Phase 1+2 evidence into write-time enforcement, add a Toss-FF code-quality pass, add a manually-invoked visual UI review skill, and trim the cold-session preflight.
+
+**Architecture:** Three layers of change:
+1. **Agents/skills** — `ds-client-review` self-loads its doc; new `toss-fe-review` agent dispatched per task; new standalone `review-ui-on-browser` skill (manual, Playwright CLI).
+2. **Docs** — `DS_CLIENT_USAGE.md` restructured (write-time decision tree on top, review rulebook on bottom) and content-extended with G1–G5 from Phase 2 evidence + MEMORY-only rules absorbed.
+3. **Orchestration** — `ds-client-constrained-execution/SKILL.md` wires the new review agent and trims wording; `CLAUDE.md` preflight goes minimal (TODO + symlink + inlined mode-detection); HARNESS/AP become consult-on-demand.
+
+**Tech Stack:** Markdown docs, Claude Code agents (.md w/ frontmatter), Claude Code skills (SKILL.md w/ frontmatter), Playwright CLI (manual install on user Mac for skill #4).
+
+**Repo:** `/Users/jiohin/Desktop/KISA/DevTeam/dev/umichkisa-ds/` (DS repo only — no client-side changes in this batch).
+
+**Branch model:** Single feature branch off `main` (this is harness/docs work, not migration lane). Recommend branch `harness-improvements-2026-04-25`. One PR.
+
+---
+
+## Phase Overview
+
+| Phase | What | Depends on | Parallelizable? |
+|---|---|---|---|
+| 1 | Update `ds-client-review` agent (self-load doc) | — | ⏸ block all later phases |
+| 2 | Restructure + extend `DS_CLIENT_USAGE.md` | Phase 1 | ⏸ block Phase 3+ |
+| 3 | Create `toss-fe-review` agent | Phase 2 (refs new doc structure) | ✅ parallel with Phase 4 |
+| 4 | Create `review-ui-on-browser` skill | Phase 2 (refs DS_CLIENT_USAGE) | ✅ parallel with Phase 3 |
+| 5 | Update `implementer-template.md` (pre-flight checklist) | Phase 2 | ✅ parallel with Phase 3, 4 |
+| 6 | Update `DS_CODEBASE.md` (implementer pointer note) | Phase 2 | ✅ parallel with Phase 3, 4, 5 |
+| 7 | Update `ds-client-constrained-execution/SKILL.md` (wire toss-fe-review, drop inline-paste, trim) | Phases 1, 3, 5 | ⏸ block Phase 8+ |
+| 8 | Update `HARNESS_DESIGN.md` + `AUTONOMOUS_PROTOCOL.md` | Phase 7 | ✅ parallel with Phase 9 |
+| 9 | Update `CLAUDE.md` preflight | Phases 7, 8 | ✅ parallel with Phase 8 |
+| 10 | Verification — re-read SKILL.md flow, `pnpm build`, `pnpm typecheck` | All | — |
+
+Phases marked ✅ parallel can be dispatched as parallel subagents. Phases marked ⏸ are gating.
+
+---
+
+## Phase 1 — `ds-client-review` agent self-loads its doc
+
+**Why first:** every other change that touches the skill assumes the agent owns its doc. Land this before SKILL.md drops the inline-paste step (Phase 7).
+
+### Task 1.1 — agent loads DS_CLIENT_USAGE.md itself
+
+**Files:**
+- Modify: `.claude/agents/ds-client-review.md` lines 11–16 (input section) and any other place that says "you will receive ... DS_CLIENT_USAGE.md"
+
+**Step 1: Replace the "Your input" block**
+
+Current (lines 11–16):
+```
+## Your input
+
+You will receive:
+1. The full content of one or more changed `.tsx` files from the client app
+2. The full content of `docs/DS_CLIENT_USAGE.md`
+```
+
+Replace with:
+```
+## Your input
+
+You will receive:
+1. The full content of one or more changed `.tsx` files from the client app
+
+## Your reference doc
+
+Before reviewing, Read `docs/DS_CLIENT_USAGE.md` (resolve relative to the umichkisa-ds repo root: `/Users/jiohin/Desktop/KISA/DevTeam/dev/umichkisa-ds/docs/DS_CLIENT_USAGE.md`). This is your authoritative ruleset. Re-read it on every invocation — do not assume cached content.
+```
+
+**Step 2: Scan agent file for any other reference assuming inline-paste**
+
+Run: `grep -n "DS_CLIENT_USAGE" .claude/agents/ds-client-review.md`
+Expected: only the new "Your reference doc" block references it. If any "you will receive ... DS_CLIENT_USAGE" leftover, remove.
+
+**Step 3: Commit**
+
+```bash
+git add .claude/agents/ds-client-review.md
+git commit -m "ds-client-review: agent reads DS_CLIENT_USAGE.md itself
+
+Move ownership of the constraint doc from caller-pasted to agent-loaded.
+Cuts ~3K tokens per review round in the parent (ds-client-constrained-execution
+skill) without changing review behavior — agent runs in its own sub-context
+and Reads the doc each invocation."
+```
+
+### Acceptance criteria
+- Agent file no longer claims it receives DS_CLIENT_USAGE.md as an input
+- Agent file instructs the reviewer to Read the file each invocation, with absolute path
+- `grep "paste DS_CLIENT_USAGE.md inline"` in `.claude/agents/ds-client-review.md` returns nothing
+
+---
+
+## Phase 2 — Restructure + extend `DS_CLIENT_USAGE.md`
+
+**Why before Phases 3–6:** new agent and template phrasings reference the new section names. Reshape and extend in one pass.
+
+**Target shape (new top-to-bottom order):**
+
+```
+# DS Client Usage Constraints
+[purpose / 3-line intro — same as today]
+
+---
+
+## Part 1 — Write-Time Decision Tree (read this BEFORE writing code)
+
+### Available DS Surface (quick-ref)
+[component list, token tier table, icon registry pointer — see Task 2.4]
+
+### Tier Picker (write-time check)
+[spacing tier picker, color picker, radius picker, type picker — see Task 2.5]
+
+### "What to Use" Rules (Must)
+[concise list — every Must rule from current doc, grouped by surface]
+
+---
+
+## Part 2 — Review-Time Rulebook (the reviewer reads this)
+
+### Setup
+### Component Usage
+### Styling
+### Icons
+### Forms
+### Layout
+### Local Components
+### className Passthrough
+### Third-Party Libraries
+### Migration-Specific
+### NEW: DS Component Defaults — Do Not Override (G1)
+### NEW: Status Variant Selection (G2)
+### NEW: Spacing Tier Mistakes (G3 — already partially in doc, expand)
+### NEW: Form Hooks Import Path (G4)
+### NEW: type-* Weight Override (G5)
+### NEW: Visibility Rule — text-muted-foreground vs text-foreground
+### NEW: No Left-Border Accent
+### NEW: Intro Foreground (intro paragraphs are primary text)
+### NEW: No Card Padding Override
+```
+
+### Task 2.1 — Move existing content into "Part 2 — Review-Time Rulebook"
+
+**Files:**
+- Modify: `docs/DS_CLIENT_USAGE.md` (whole file rewrite)
+
+**Step 1: Read current full doc** (already done — 144 lines).
+
+**Step 2: Create the new shell**
+
+Open the doc, keep lines 1–7 (purpose/intro) plus the existing horizontal rule, then insert under it:
+
+```markdown
+## Part 1 — Write-Time Decision Tree
+
+_Read this BEFORE writing any line of client code that touches UI. Implementers: this is your write-time cheat sheet. Reviewers: skip to Part 2 — Review-Time Rulebook below._
+
+[Tasks 2.4 + 2.5 + 2.6 fill this in]
+
+---
+
+## Part 2 — Review-Time Rulebook
+
+_Full constraint taxonomy. The `ds-client-review` agent scans this end-to-end._
+```
+
+Then move all current sections (Setup → Migration-Specific) **under Part 2** verbatim. Do not change content yet — just reposition.
+
+**Step 3: Commit (intermediate, structural only)**
+
+```bash
+git add docs/DS_CLIENT_USAGE.md
+git commit -m "DS_CLIENT_USAGE: split into Part 1 (write-time) / Part 2 (review)
+
+Structural-only — no rule changes. Existing content is moved verbatim under
+Part 2. Part 1 is a placeholder filled by subsequent commits."
+```
+
+### Task 2.2 — Add G1: Do Not Override DS Layout Components
+
+**Files:**
+- Modify: `docs/DS_CLIENT_USAGE.md` — add section under Part 2 (after current "className Passthrough" section)
+
+**Step 1: Add this section content under Part 2**
+
+```markdown
+### DS Component Layout — Do Not Override (G1)
+
+Never: Add flex / overflow / height / max-height utility classes to a DS layout component (`Dialog`, `DialogContent`, `Tabs`, `TabsList`, `TabsContent`, `Form`, `Card`, `CardContent`, `CardFooter`, `Sheet`, `Drawer`) to force size or layout. The DS owns the layout pattern of these components — flex containers, gap spacing, overflow behavior. Adding `flex flex-1 overflow-hidden` to `<Tabs>` or `<Form>` to make them fill height is fighting the DS. [source:phase-2/lane-2.11b smoke fix, commit c4cea05]
+
+If a layout doesn't fit:
+- Cap inner content with `max-h-[60vh]` (or similar) on the inner content child (e.g., `<TabsContent>`), not on the outer DS layout component
+- If the cap doesn't solve it, the DS component is missing a variant — collect via `ds-fix-during-migration`
+
+Allowed (positioning passthrough): `mt-4`, `w-full`, `mx-auto`, `hidden md:block` on DS components — these are layout/positioning, not internal layout overrides.
+
+Disallowed examples (would have been caught here in Phase 2):
+- `<Tabs className="flex flex-1 flex-col overflow-hidden">` — overrides DS Tabs layout
+- `<Form className="flex flex-1 flex-col gap-4 overflow-hidden">` — overrides DS Form layout
+- `<DialogContent className="max-h-[90dvh] flex flex-col">` — DS Dialog now owns this; override is redundant
+
+Allowed:
+- `<TabsContent className="max-h-[60vh] overflow-y-auto">` — height cap on inner content, not on DS layout
+```
+
+**Step 2: Commit**
+
+```bash
+git add docs/DS_CLIENT_USAGE.md
+git commit -m "DS_CLIENT_USAGE: add G1 (no override on DS layout components)
+
+From Phase 2 lane 2.11b smoke fix (commit c4cea05): implementer applied
+flex/overflow utilities to <Tabs> and <Form> to force fill-height, fighting
+DS layout. Codify the rule: do not add layout overrides to DS layout
+components; use max-h on inner content instead."
+```
+
+### Task 2.3 — Add G2 through G5
+
+**Files:**
+- Modify: `docs/DS_CLIENT_USAGE.md`
+
+**Step 1: G2 — Status Variant Selection**
+
+Add under Part 2 (near `Component Usage`):
+
+```markdown
+### Status Variant Selection (G2)
+
+Must: When a `Badge`, `Alert`, or other DS feedback component expresses status, use the **semantic** variant — `success`, `warning`, `error`, `info` — not the neutral/outline variant.
+
+Status content includes: "available now" / "즉시 제공" → `success`; "age check required" / "연령 확인" → `warning`; error states → `error`; passive informational → `info`.
+
+`outline` / default neutral is for non-status content (categorical tags, generic labels).
+
+[source:phase-2/lane-2.11b smoke fix, commit 59462d4]
+```
+
+**Step 2: G3 — Spacing Tier (expand existing layout section)**
+
+Find the existing `### Layout` section in Part 2. Append after `Must: Follow the three-tier vertical spacing system`:
+
+```markdown
+**Tier-justify every spacing value before writing.** Spacing inside a single component (image+text inside a row, label+input inside a field, icon+text inside a chip) is **Component or Element tier** (`gap-2` / `gap-3` / `gap-4`), not Section tier. `gap-6`/`gap-8` are reserved for boundaries between major page sections. [source:phase-2/lane-2.11b smoke fix, commit 59462d4 — `gap-6` → `gap-4` correction on row internals]
+
+Write-time check (when picking a `gap-*` / `space-*` value):
+1. What is the role of the container? (page section / component-internal / inline)
+2. Is the chosen value the canonical tier value for that role? (8 / 16 / 24 px = `gap-2` / `gap-4` / `gap-6`)
+3. If you cannot answer (1) and (2) cleanly, do not write the value — ask.
+```
+
+**Step 3: G4 — Form Hooks Import Path**
+
+Find the existing `### Forms` section. Replace the current `Never: Import \`react-hook-form\` directly` line with:
+
+```markdown
+Never: Import any RHF symbol (`useForm`, `useFormField`, `useFormStatus`, `useFormContext`, `useFormState`, `useWatch`, `Controller`) directly from `react-hook-form`. Always use `@umichkisa-ds/form` re-exports. The DS form package wraps `useForm` with `mode: "onTouched"` and other defaults; bypassing the wrapper produces inconsistent validation timing and breaks the DS form contract.
+
+If a hook you need is not yet re-exported by `@umichkisa-ds/form`, treat it as a DS gap and run `ds-fix-during-migration` to add the re-export — do not import from `react-hook-form` as a workaround. [source:phase-2/lane-2.19 — `useFormContext` was missing from `@umichkisa-ds/form`; required form 1.0.1 re-export commit 086c148]
+```
+
+**Step 4: G5 — type-\* Weight Override**
+
+Find the existing `### Tokens` section under `Styling`. Add after the existing `Must: Use \`type-*\` semantic utility classes` line:
+
+```markdown
+Never: Override the weight of a `type-*` class with `!font-*` (e.g., `type-body !font-semibold`, `type-h2 !font-bold`). The `type-*` tier already bakes weight, font-family, and line-height. If a different weight is needed, pick a different `type-*` class — do not override. [source:MEMORY/feedback_type_weight_override; phase-2/lane-2.19 commit 09d2cd0 swept these out]
+
+Exception during migration: short-lived `!font-*` overrides may exist when the type-* tier doesn't yet expose the desired weight. Collect these as a DS gap (request a new `type-*` tier or a weight variant via `ds-fix-during-migration`); do not let them ship long-term.
+```
+
+**Step 5: Commit (one commit covering G2–G5)**
+
+```bash
+git add docs/DS_CLIENT_USAGE.md
+git commit -m "DS_CLIENT_USAGE: add G2–G5 from Phase 2 evidence
+
+G2: Status variant selection — semantic, not outline (lane 2.11b)
+G3: Spacing tier write-time check — gap-6 ≠ component-internal (lane 2.11b)
+G4: Form hooks import path — never bypass @umichkisa-ds/form (lane 2.19)
+G5: type-* weight override prohibition (MEMORY rule, lane 2.19 sweep)"
+```
+
+### Task 2.4 — Add "Available DS Surface" quick-ref (Part 1)
+
+**Files:**
+- Modify: `docs/DS_CLIENT_USAGE.md` — fill in Part 1 first section
+
+**Step 1: Generate the quick-ref content**
+
+The implementer needs to know: which components exist, which token classes exist, where icons come from. This is a curated subset of `DS_CODEBASE.md`. Read `docs/DS_CODEBASE.md` and extract:
+- Component list with import path + one-line use ("Button — `@umichkisa-ds/web`, primary actions")
+- Token utility classes (`text-foreground`, `bg-surface`, `border-brand-primary`, `type-h1` through `type-caption`)
+- Icon source: `<Icon name="..." />` from `@umichkisa-ds/web` — registry at `packages/web/src/components/icon/registry.ts`
+- Form components: `Form.Input`, `Form.Textarea`, `Form.Select`, `Form.Checkbox`, `Form.Radio`, `Form.Switch`, `Form.Button` from `@umichkisa-ds/form`
+- Hooks: `useForm`, `useFormField`, `useFormStatus`, `useFormContext` from `@umichkisa-ds/form`
+
+Insert under `## Part 1 — Write-Time Decision Tree` as the first subsection:
+
+```markdown
+### Available DS Surface (quick-ref)
+
+For complete details, see `DS_CODEBASE.md`. This subset covers the surface most lanes need.
+
+**Components (`@umichkisa-ds/web`):**
+- Layout: `Container`, `Card` (+ `CardHeader`, `CardContent`, `CardFooter`, `CardTitle`, `CardDescription`)
+- Surfaces: `Dialog`, `Sheet`, `Drawer`, `Popover`, `Tooltip`, `HoverCard`
+- Inputs (raw — prefer `Form.*` from form package): `Button`, `Badge`, `Avatar`
+- Feedback: `StatusView` (variants: `not-authorized`, `not-found`, `not-logged-in`, `error`, `loading`; `fullScreen` prop), `Alert` (variants: `success`, `warning`, `error`, `info`), `LoadingSpinner`
+- Navigation: `Tabs` (+ `TabsList`, `TabsTrigger`, `TabsContent`), `Accordion`, `DropdownMenu`, `NavigationMenu`
+- Toast: `Toaster` (mount once at root), `toast()` from `@umichkisa-ds/web`
+- Utility: `cn()`, `Icon`
+
+**Form components (`@umichkisa-ds/form`):**
+- Compounds: `Form.Input`, `Form.Textarea`, `Form.Select`, `Form.Checkbox`, `Form.Radio`, `Form.Switch`, `Form.Button`
+- Hooks: `useForm`, `useFormField`, `useFormStatus`, `useFormContext`
+
+**Token classes (Tailwind v4 @theme):**
+- Color: `text-foreground`, `text-muted-foreground`, `bg-surface`, `bg-surface-subtle`, `bg-brand-primary`, `bg-brand-accent`, `bg-brand-accent-subtle`, `border-border`, `border-border-strong`, `border-brand-primary`, plus status: `bg-success`, `bg-warning`, `bg-error`, `bg-info`
+- Typography: `type-display`, `type-h1`, `type-h2`, `type-h3`, `type-body`, `type-body-lg`, `type-body-sm`, `type-label`, `type-caption`
+- Spacing tiers: `gap-2` / `gap-4` / `gap-6` (Element / Component / Section)
+- Radius: `rounded-sm`, `rounded-md`, `rounded-lg`, `rounded-full`
+- Breakpoints: default, `md:`, `lg:` only
+
+**Icons:**
+- `<Icon name="..." size="xs|sm|md|lg|xl" />` from `@umichkisa-ds/web`. Registry: `packages/web/src/components/icon/registry.ts`. If a name is missing, use `ds-fix-during-migration`.
+```
+
+**Step 2: Commit**
+
+```bash
+git add docs/DS_CLIENT_USAGE.md
+git commit -m "DS_CLIENT_USAGE: add Part 1 'Available DS Surface' quick-ref
+
+Implementer-facing component / token / icon catalog so the implementer
+doesn't need to also read DS_CODEBASE.md. Content is a curated subset
+of DS_CODEBASE.md, deliberately denormalized for write-time use."
+```
+
+### Task 2.5 — Add Tier Picker (Part 1)
+
+**Files:**
+- Modify: `docs/DS_CLIENT_USAGE.md`
+
+**Step 1: Add this subsection under Part 1, after "Available DS Surface"**
+
+```markdown
+### Tier Picker (write-time check)
+
+Before writing any spacing / color / radius / text / icon-size value, identify its tier and pick the canonical token. If you cannot tier-justify a value, do not write it — flag it and ask.
+
+**Spacing (gap, padding, margin):**
+- Element tier (8px) → `gap-2`, `space-x-2`, `p-2` — icon+text, button+icon, tag clusters, inline groups
+- Component tier (16px) → `gap-4`, `space-y-4`, `p-4` — between sibling components inside a feature, list items, stacked form fields, card internals
+- Section tier (24px) → `gap-6`, `space-y-6`, `p-6` — between major page sections, page-level container padding
+- Off-tier (gap-3, gap-5, gap-7) → only inside a single component's internal layout (e.g., `p-3` on a chip is fine; `gap-3` between siblings is wrong)
+
+**Color (text):**
+- Primary content → `text-foreground` (body, labels users read, card values, headers)
+- Genuinely secondary → `text-muted-foreground` (captions, helper text, metadata, timestamps, placeholder hints)
+- Test: "if this text went to 40% opacity, would the screen still be usable?" If no, it's primary; keep `text-foreground`.
+
+**Color (background / border):**
+- Surfaces → `bg-surface` (cards), `bg-surface-subtle` (subtle blocks)
+- Brand → `bg-brand-primary`, `bg-brand-accent`, `bg-brand-accent-subtle`
+- Status (Badge/Alert) → `bg-success`, `bg-warning`, `bg-error`, `bg-info` (or use semantic variants on DS components)
+- Borders → `border-border` (default), `border-border-strong` (emphasized), `border-brand-primary` (brand emphasis)
+
+**Radius:**
+- `rounded-sm` / `rounded-md` → buttons, inputs, cards (default DS)
+- `rounded-lg` → modals, larger surfaces
+- `rounded-full` → avatars, pills
+- `rounded-xl` / `rounded-2xl` → only with explicit DS-surface justification
+
+**Typography:**
+- Display / hero → `type-display`
+- Headings → `type-h1`, `type-h2`, `type-h3`
+- Body → `type-body` (default), `type-body-lg` (lead paragraphs), `type-body-sm` (compact)
+- Labels → `type-label` (form labels, button labels)
+- Captions → `type-caption` (metadata, timestamps)
+- Always pair with a color token (`type-*` does not set color).
+- Never override weight with `!font-*` — pick a different `type-*` class.
+
+**Icon size:**
+- 5-step scale: `xs` / `sm` / `md` / `lg` / `xl`
+- Never override with font-size utilities or arbitrary CSS.
+```
+
+**Step 2: Commit**
+
+```bash
+git add docs/DS_CLIENT_USAGE.md
+git commit -m "DS_CLIENT_USAGE: add Part 1 'Tier Picker' write-time check
+
+Forces the implementer to tier-justify every spacing/color/radius/type/icon
+value before writing. Codifies the 'redesign over preserve, at write time'
+principle that was added to the skill but not enforced by the doc."
+```
+
+### Task 2.6 — Add "What to Use" Rules (Part 1) + absorb MEMORY-only rules
+
+**Files:**
+- Modify: `docs/DS_CLIENT_USAGE.md`
+
+**Step 1: Add this subsection under Part 1, after "Tier Picker"**
+
+```markdown
+### "What to Use" Rules (Must)
+
+A condensed, write-time view of the Must rules from Part 2. Read Part 2 for full context and source citations.
+
+- Use `Container` for page shells. Never compose `mx-auto max-w-screen-2xl px-4 ...` manually.
+- Use `Form.*` compounds + `useForm` from `@umichkisa-ds/form` for all forms. Never `useState` for form state.
+- Use `<Icon name="..." />` from `@umichkisa-ds/web` for all icons. Never `react-icons`, never direct `lucide-react`, never inline SVGs.
+- Use `cn()` from `@umichkisa-ds/web` for all className merging. Never raw `clsx` or string concatenation.
+- Use `StatusView` (variants + `fullScreen` prop) for full-page status. Never `<div className="h-screen flex items-center">` wrappers.
+- Use semantic Badge / Alert variants for status content (`success`, `warning`, `error`, `info`). Never `outline` for status.
+- Use breakpoints `default` / `md:` / `lg:` only. Never `sm:`, `xl:`, `2xl:`.
+- Use `type-*` classes paired with a color token. Never override with `!font-*`.
+- Cap inner content with `max-h-[…]` if a DS layout component (Dialog, Tabs, Form, Card) doesn't fit. Never apply `flex` / `overflow-*` to the DS component to force fill.
+
+### Visibility & Hierarchy Rules
+
+- **`text-muted-foreground` is NOT default body color.** Reserve for *genuinely secondary* content (captions, helper text, metadata, timestamps). Card values, list labels, body paragraphs, form labels stay `text-foreground`. [source:MEMORY/feedback]
+- **Intro paragraphs are primary content.** A page's lead paragraph or section intro is `text-foreground`, not muted. [source:MEMORY/feedback_intro_foreground]
+- **No left-border accent for selected state.** Use `bg-brand-accent-subtle border-brand-primary` (full border ring), not a `border-l-4` accent stripe. [source:MEMORY/feedback_no_left_border]
+- **No padding override on Card / CardContent / CardFooter.** Respect component defaults. If padding feels wrong, the Card is being misused for a non-card surface — pick a different DS component. [source:MEMORY/feedback_card_no_override]
+```
+
+**Step 2: Commit**
+
+```bash
+git add docs/DS_CLIENT_USAGE.md
+git commit -m "DS_CLIENT_USAGE: add Part 1 'What to Use' + absorb MEMORY rules
+
+Condensed Must list for write-time scanning, plus visibility/hierarchy
+rules previously living only in MEMORY (text-muted-foreground visibility,
+intro foreground, no-left-border, no-card-padding-override)."
+```
+
+### Acceptance criteria (Phase 2)
+- `docs/DS_CLIENT_USAGE.md` opens with Part 1 (Available DS Surface → Tier Picker → What to Use → Visibility) and ends with Part 2 (full rulebook).
+- All G1–G5 sections present in Part 2.
+- All listed MEMORY rules present in Part 1's Visibility & Hierarchy block.
+- Word count grew from ~144 to ~300–350 lines (estimate). Confirm with `wc -l docs/DS_CLIENT_USAGE.md`.
+
+---
+
+## Phase 3 — Create `toss-fe-review` agent (parallel-safe)
+
+### Task 3.1 — Write the agent file
+
+**Files:**
+- Create: `.claude/agents/toss-fe-review.md`
+
+**Step 1: Write the agent**
+
+Full content:
+
+```markdown
+---
+name: toss-fe-review
+description: Frontend code-quality reviewer applying Toss Frontend Fundamentals (readability, predictability, cohesion, coupling). Use after ds-client-review passes on a task that touches .tsx files. Returns structured findings with severity gates so the orchestrator can decide whether to re-dispatch the implementer.
+tools: Read, Glob
+---
+
+# Toss FE Code-Quality Reviewer
+
+You are a focused code-quality reviewer applying the Toss Frontend Fundamentals rubric. Your only job is to flag readability / predictability / cohesion / coupling smells in the changed `.tsx` files. Do not check DS constraints (a separate agent owns that). Do not check perf (vercel-react-best-practices owns that at end-of-feature).
+
+## Your input
+
+You will receive the full content of one or more changed `.tsx` files from the client app. The orchestrator may also paste relevant adjacent files for context (parents, siblings, hook callers).
+
+## Rubric — four axes
+
+### Readability — how fast can a new reader understand this code?
+
+- Functions are short and single-purpose. Threshold: a single function or component body > 80 lines is a candidate for extraction; > 120 lines is a clear smell.
+- Conditional logic is named. Inline `condition1 && condition2 || ...` chains buried in JSX should be lifted to a named const (`const canSubmit = ...`).
+- Magic numbers / strings have names. `if (count > 7)` is a smell; `const MAX_ITEMS = 7; if (count > MAX_ITEMS)` is not.
+- Ternaries nest at most 2 deep. `a ? b : c ? d : e` is the limit. `a ? b : (c ? d : (e ? f : g))` is a clear smell.
+- Code reads top-to-bottom. Time-traveling (declaring a hook before its dependencies are defined, or referencing later-declared helpers without `function` hoisting) hurts readability.
+- Mixed concerns in one function (data fetching + transformation + render decisions) should split.
+
+### Predictability — does the code do what its name implies?
+
+- Same-shape functions return same-shape types. If `getUser()` returns `User`, `getOrder()` should return `Order`, not sometimes `null` and sometimes throwing.
+- No name collisions across module / hook / variable scope.
+- A "useFoo" hook returns the canonical shape `{ data, error, isLoading }` (or `{ data, error, isLoading, refetch }`) consistently across hooks in the same feature.
+- No hidden side effects. A function named `formatDate` should not also mutate global state.
+
+### Cohesion — does code that changes together live together?
+
+- Field-level validation logic colocated with the field, not in a top-level form file.
+- Helpers used only by one component live next to that component, not in a shared `utils/` until they're used by ≥ 2 callers.
+- Sub-components that exist only to be passed to one parent live in the parent's file (or a `_shared/` sibling), not a top-level component dir.
+- Cross-field validation logic colocates at the form root with `useFormContext`, not duplicated in each field.
+
+### Coupling — when this changes, what else has to change?
+
+- Components don't reach into siblings' internals. Communicate via props or a shared parent.
+- I/O (Cloudinary calls, fetch, localStorage access) lives in a dedicated `apis/` or hook layer, not inline in components.
+- Type casts (`as Foo`) for `next-auth` session, query params, etc. are centralized in a wrapper hook, not scattered.
+- Deep prop drilling (> 2 levels of `prop` passthrough that the middle layers don't use) is a smell — prefer composition or context.
+
+## Severity gate
+
+Every finding has a severity. The orchestrating skill uses severity to decide what to do.
+
+- **BLOCK** — must be fixed before commit. Re-dispatches the implementer with the finding. Reserved for severe smells:
+  - Function / component body > 80 lines AND mixing concerns (e.g., data + transformation + render in one block)
+  - Ternary depth > 3
+  - Clear duplication (≥ 2 copies of the same 5+ line block in the same file or sibling files)
+  - Leaky abstraction across module boundary (a low-level util reaches into a domain type, or a domain type carries a UI concern)
+  - I/O inline in a component (raw fetch / Cloudinary / localStorage) when the codebase has an established hook/api layer
+- **SUGGEST** — note in PR body, not blocking. Default for most findings: extract a helper, name a magic number, lift a conditional to a named const, colocate a sub-component.
+- **INFO** — purely advisory, no PR-body note. Style preferences, micro-readability nits.
+
+Default disposition is conservative. **When in doubt, downgrade to SUGGEST.** The over-refactor risk (nightly autonomous lanes spinning on Toss-FF re-dispatches) is worse than a missed BLOCK.
+
+Style preferences (one-liner vs. helper for trivial single-call cases, prefer-const-vs-let, arrow-vs-function) are NEVER BLOCK. Often INFO or skipped entirely.
+
+## Output format
+
+For every finding:
+
+```
+FINDING N [BLOCK|SUGGEST|INFO]
+File: <file path>:<line number>
+Axis: readability | predictability | cohesion | coupling
+Smell: <one-line problem statement>
+Suggested refactor: <concrete change or extraction>
+```
+
+End every response with a result line:
+
+```
+---
+Result: B BLOCK, S SUGGEST, I INFO finding(s)
+```
+
+If fully clean:
+
+```
+---
+Result: PASS — no findings
+```
+
+## Rules for reviewing
+
+- Be specific about line numbers
+- Only report Toss-FF rubric smells — not DS constraints (ds-client-review's job), not perf (vercel-react-best-practices' job)
+- Concrete suggestions only — "make this more readable" is not actionable; "extract `validatePochaInfo` to `_shared/validate.ts`" is
+- Do NOT BLOCK on style preferences
+- Do NOT BLOCK on the user's commit habits, naming idioms, or framework choices
+- If the file is < 30 lines and does one thing, default to PASS — short focused code is the goal
+- BLOCK threshold is intentionally narrow: severe smells only
+```
+
+**Step 2: Commit**
+
+```bash
+git add .claude/agents/toss-fe-review.md
+git commit -m "agent: add toss-fe-review (frontend code-quality reviewer)
+
+New agent applying the four Toss FF axes (readability, predictability,
+cohesion, coupling) with a conservative BLOCK / SUGGEST / INFO severity
+gate. Wired into ds-client-constrained-execution per-task flow in a
+separate commit. Designed with a minimum-change disposition to avoid
+over-refactor loops in autonomous routines."
+```
+
+### Acceptance criteria
+- `.claude/agents/toss-fe-review.md` exists with the four-axis rubric, severity gate, output format, and conservative defaults
+- Agent uses only `Read` and `Glob` tools (matches `ds-client-review` shape)
+- Frontmatter `description` triggers cleanly on "use after ds-client-review on .tsx tasks"
+
+---
+
+## Phase 4 — Create `review-ui-on-browser` skill (parallel-safe)
+
+### Task 4.1 — Write the skill file
+
+**Files:**
+- Create: `.claude/skills/review-ui-on-browser/SKILL.md`
+
+**Step 1: Write the skill**
+
+Full content:
+
+```markdown
+---
+name: review-ui-on-browser
+description: Visual UI/UX review of a running localhost dev server using Playwright CLI. Use when the user wants Claude to look at the actual rendered UI on the browser (not just static code) and produce findings on hierarchy, spacing, primary action visibility, loading/empty/error states, and content readability. Manually invoked — not wired into autonomous routines.
+---
+
+# Review UI On Browser
+
+## When to invoke
+
+Manually, by the user, during:
+- **Mode C (PR review)** — after checking out the branch and starting the dev server, before merge approval, to catch visual issues a human reviewer might miss
+- **Mode D (interactive execution)** — after a UI-touching task completes, before `git commit`, to sanity-check the rendered result
+
+NOT invoked from:
+- `ds-client-constrained-execution` skill (intentional — Vercel preview auth + per-branch URL constraints make this impractical for autonomous use)
+- Autonomous nightly routine (same)
+
+## Prerequisites (one-time setup on the user's Mac)
+
+```bash
+# In ANY directory — Playwright manages its own browser binaries:
+npx playwright install chromium
+```
+
+This downloads the Chromium browser binary (~150MB, ~2 min). Once installed, subsequent invocations skip this step.
+
+## Prerequisites (per invocation)
+
+The user must have:
+1. Checked out the branch they want to review
+2. Started the dev server (`cd ../KISA-website/client && npm run dev`)
+3. Confirmed the dev server is reachable at the URL they pass to the skill (default `http://localhost:3000`)
+
+The skill does NOT start the dev server. It assumes the running server.
+
+## Inputs (the user tells the skill these)
+
+- **Base URL** (default `http://localhost:3000`)
+- **Routes** to visit (e.g., `["/pocha/manage", "/pocha/manage/?dialog=open"]`)
+- **Key flows** (optional — descriptions like "open the create dialog, fill the info tab, switch to menu tab")
+- **Viewports** (default `[{ width: 1280, height: 800, label: "desktop" }, { width: 375, height: 812, label: "mobile" }]`)
+- **What changed** (a 1–2 sentence summary of what the user wants reviewed — e.g., "the PochaForm dialog redesign with sticky footer")
+
+## Process
+
+For each route × viewport combination:
+
+1. Launch a headless browser via `npx playwright`
+2. Navigate to `<baseURL><route>`
+3. Set viewport size
+4. Wait for `networkidle`
+5. Screenshot — save to `/tmp/review-ui-on-browser/<timestamp>/<route-slug>-<viewport-label>.png`
+6. Capture the accessibility tree (Playwright `page.accessibility.snapshot()`)
+7. If a flow is described, walk through it (click selectors, fill inputs) — screenshot at each step
+
+After captures, review every screenshot against the rubric below and return findings.
+
+## Rubric
+
+For each screenshot, evaluate:
+
+### Hierarchy
+- Is the primary action visually prominent (size, color, position)?
+- Are headings clearly differentiated by size + weight from body text?
+- Does the visual order match the intended reading order?
+
+### Spacing rhythm
+- Consistent gap tier within sections? (No `gap-2` jumping to `gap-6` arbitrarily)
+- Page padding consistent with siblings on adjacent routes?
+- Component-internal padding feels deliberate, not cramped or floating?
+
+### Primary action visibility
+- Can the user tell what to do next within 2 seconds of looking?
+- Disabled / loading states distinct from the active state?
+- Submit button position predictable (sticky footer for forms, end of card for actions)?
+
+### State coverage
+- Loading: a skeleton, spinner, or text placeholder is visible during data fetch
+- Empty: empty state has helpful text + (if applicable) a primary action to fill it
+- Error: error state has a clear message + recovery path
+- All three states reachable in the routes/flows visited
+
+### Content readability
+- Body text uses primary foreground color (not muted-foreground for content the user must read)
+- Status content uses semantic colors (success/warning/error/info), not muted neutrals
+- No content overflow / text clipping at either viewport
+- Korean + English text both render with their intended type tier
+
+### Mobile (375px) specifics
+- Tap targets ≥ 44×44 px
+- No horizontal scroll on the body
+- Modals / dialogs adapt to viewport (no offscreen content)
+- Sticky footer stays in view during keyboard open (best-effort; flag if you can't tell)
+
+## Output format
+
+Per finding:
+
+```
+FINDING N [BLOCK|SUGGEST|INFO]
+Screenshot: /tmp/review-ui-on-browser/<timestamp>/<route-slug>-<viewport-label>.png
+Route: <route>
+Viewport: <viewport label>
+Smell: <one-line problem>
+Suggested fix: <concrete change in code or design>
+```
+
+Severity:
+- **BLOCK** — broken UX (overflow, content unreachable, primary action invisible, error state missing)
+- **SUGGEST** — visible polish issue (spacing rhythm, hierarchy off, status badge wrong variant)
+- **INFO** — minor polish or alternative
+
+End with a summary:
+
+```
+---
+Reviewed: <N> route(s) × <M> viewport(s)
+Screenshots: /tmp/review-ui-on-browser/<timestamp>/
+Result: B BLOCK, S SUGGEST, I INFO finding(s)
+```
+
+If clean:
+
+```
+Result: PASS — no findings
+```
+
+## Implementation notes
+
+- Use `npx playwright codegen` patterns mentally; do not actually invoke codegen
+- Run Playwright in headless mode (`--headed` is for the user to debug, not for the skill)
+- Capture each screenshot as PNG
+- The screenshots are the primary artifact — text findings reference them with absolute paths so the user can open them
+- If `npx playwright install chromium` has not been run, fail early with the install instruction — do NOT silently install
+- Do not modify any client files. Do not run dev server. Do not commit anything.
+
+## Common pitfalls
+
+- Forgetting to wait for `networkidle` before screenshot → captures loading skeleton instead of loaded UI
+- Mixing up base URL with route — base URL is `http://localhost:3000`, route is `/pocha/manage`
+- Reviewing only desktop — always include mobile (375px) at minimum
+- Reporting findings without absolute screenshot paths — the user must be able to open the image to verify
+```
+
+**Step 2: Commit**
+
+```bash
+git add .claude/skills/review-ui-on-browser/SKILL.md
+git commit -m "skill: add review-ui-on-browser (manual visual UI review)
+
+Standalone skill, manually invoked. Uses Playwright CLI (one-time
+\`npx playwright install chromium\` on user's Mac). Takes localhost
+URL + routes + flows + viewports, captures screenshots, evaluates
+against UI/UX rubric (hierarchy, spacing rhythm, primary action,
+state coverage, content readability, mobile specifics).
+
+Not wired into autonomous routine — Vercel preview auth + free-tier
+dev-only branch make per-PR Playwright impractical. User invokes
+during PR review (after checkout + dev server) or after a UI-touching
+Mode D task before commit."
+```
+
+### Acceptance criteria
+- `.claude/skills/review-ui-on-browser/SKILL.md` exists
+- Frontmatter description makes it discoverable when user asks "review the UI" / "look at this in the browser"
+- Skill explicitly states it does NOT start the dev server, assumes it's running
+- Rubric covers hierarchy / spacing / primary action / state coverage / readability / mobile
+
+---
+
+## Phase 5 — Update `implementer-template.md` (parallel-safe)
+
+### Task 5.1 — Add write-time pre-flight checklist
+
+**Files:**
+- Modify: `.claude/skills/ds-client-constrained-execution/implementer-template.md` lines 22–28 (the "Your Job" block)
+
+**Step 1: Insert pre-flight block before "Your Job"**
+
+Find this in the template (around line 21):
+
+```
+    ## Your Job
+
+    Implement **Step 1 only** — create or modify the files as specified.
+```
+
+Insert this block ABOVE `## Your Job`:
+
+```
+    ## Pre-flight (do this FIRST — before writing any code)
+
+    Read `docs/DS_CLIENT_USAGE.md` Part 1 (Write-Time Decision Tree). Then,
+    for the task you're about to implement, list every styling decision
+    you'll make and its DS tier or token justification:
+
+    1. Spacing values — list every `gap-*`, `space-*`, `p*`, `m*` you'll write,
+       with the role of its container (Element / Component / Section / inline)
+       and the canonical tier value.
+    2. Color values — list every `text-*`, `bg-*`, `border-*` and which DS
+       semantic token applies (`text-foreground` vs `text-muted-foreground`,
+       `bg-surface` vs `bg-brand-accent-subtle`, etc.).
+    3. Radius values — list every `rounded-*` and the DS surface role.
+    4. Type values — list every `type-*` class with its color pairing.
+    5. Icon names + sizes — list every `<Icon name="..." size="...">` you'll
+       write. If a name is missing from the registry, flag it as a DS gap.
+
+    If you cannot tier-justify a value, do NOT write it — flag it as a
+    question in your report and stop. The reviewer will not catch every
+    off-tier value; you must catch them at write time.
+
+    This is the "redesign over preserve" principle: when the original
+    code's value conflicts with the DS tier, ship the DS-canonical value,
+    not a mechanical demotion. Record every such choice as a "Deviation
+    from original" line for the PR body.
+
+```
+
+**Step 2: Adjust the existing "DS Client Usage Constraints" block**
+
+Find this (around line 32–37):
+
+```
+    ## DS Client Usage Constraints
+
+    Follow every rule below as you write code. A constraint review agent will verify your
+    output — aim for zero violations on the first pass.
+
+    [PASTE FULL CONTENTS OF docs/DS_CLIENT_USAGE.md HERE]
+```
+
+Replace with:
+
+```
+    ## DS Client Usage Constraints
+
+    Follow every rule in `docs/DS_CLIENT_USAGE.md`. A constraint review agent
+    will verify your output — aim for zero violations on the first pass.
+
+    Read the full file before writing. Part 1 (Write-Time Decision Tree)
+    is your primary guide; Part 2 (Review-Time Rulebook) is what the
+    reviewer will check you against.
+
+    [PASTE FULL CONTENTS OF docs/DS_CLIENT_USAGE.md HERE]
+```
+
+(Keep the paste — implementer still gets the full doc inline. We reinforce that Part 1 is the write-time guide.)
+
+**Step 3: Commit**
+
+```bash
+git add .claude/skills/ds-client-constrained-execution/implementer-template.md
+git commit -m "implementer-template: add pre-flight tier-justification checklist
+
+Forces implementer to enumerate every spacing / color / radius / type / icon
+value with DS tier justification BEFORE writing code. Reinforces the
+'redesign over preserve at write time, not review time' principle and
+addresses the recurring G3 (spacing tier mismatch) finding from Phase 2.
+
+Also points implementer at DS_CLIENT_USAGE.md Part 1 / Part 2 split."
+```
+
+### Acceptance criteria
+- `implementer-template.md` has a "Pre-flight" section above "Your Job"
+- Pre-flight enumerates the 5 categories (spacing, color, radius, type, icon)
+- The existing inline-paste of DS_CLIENT_USAGE.md is preserved (only the framing changed)
+
+---
+
+## Phase 6 — Update `DS_CODEBASE.md` pointer (parallel-safe)
+
+### Task 6.1 — Add implementer pointer note
+
+**Files:**
+- Modify: `docs/DS_CODEBASE.md` (top of file, after the title)
+
+**Step 1: Locate the doc**
+
+Run: `head -10 docs/DS_CODEBASE.md`
+
+**Step 2: Insert this note immediately after the H1 title**
+
+```markdown
+> **Implementers, read `docs/DS_CLIENT_USAGE.md` instead.** This doc is the
+> human-facing DS surface catalog used during planning / grill / discovery —
+> not the write-time enforcement doc. The `ds-client-review` agent and the
+> implementer subagent both read `DS_CLIENT_USAGE.md`, which has a Part 1
+> ("Available DS Surface" + tier picker + write-time rules) curated for
+> implementers and a Part 2 (full constraint rulebook) for the reviewer.
+```
+
+**Step 3: Commit**
+
+```bash
+git add docs/DS_CODEBASE.md
+git commit -m "DS_CODEBASE: point implementers at DS_CLIENT_USAGE.md
+
+Disambiguates the two docs: DS_CODEBASE is human-facing discovery
+(used in grill / planning); DS_CLIENT_USAGE is write-time + review-time
+enforcement (used by implementer + reviewer agents)."
+```
+
+### Acceptance criteria
+- `DS_CODEBASE.md` opens with a clear note redirecting implementers to `DS_CLIENT_USAGE.md`
+
+---
+
+## Phase 7 — Update `ds-client-constrained-execution/SKILL.md`
+
+**Why this phase is gating:** wires the new toss-fe-review pass + drops the inline-paste from ds-client-review invocation + trims wording. Depends on Phases 1, 3, 5.
+
+### Task 7.1 — Drop inline-paste of DS_CLIENT_USAGE.md from ds-client-review invocation
+
+**Files:**
+- Modify: `.claude/skills/ds-client-constrained-execution/SKILL.md` lines 159–168 (DS Client Review section)
+
+**Step 1: Replace the "What to pass in the agent prompt" block**
+
+Find this:
+
+```markdown
+**What to pass in the agent prompt:**
+1. The full content of each changed `.tsx` file (paste inline)
+2. The full content of `docs/DS_CLIENT_USAGE.md` (paste inline)
+3. Instruction: return structured violations per the agent's output format
+```
+
+Replace with:
+
+```markdown
+**What to pass in the agent prompt:**
+1. The full content of each changed `.tsx` file (paste inline)
+2. Instruction: return structured violations per the agent's output format
+
+The agent reads `docs/DS_CLIENT_USAGE.md` itself — do not paste it inline.
+```
+
+**Step 2: Commit (intermediate)**
+
+```bash
+git add .claude/skills/ds-client-constrained-execution/SKILL.md
+git commit -m "skill: drop DS_CLIENT_USAGE.md inline-paste from ds-client-review invocation
+
+Agent now reads the doc itself (Phase 1). Saves ~3K tokens per review
+round in the orchestrating skill."
+```
+
+### Task 7.2 — Wire toss-fe-review into per-task flow
+
+**Files:**
+- Modify: `.claude/skills/ds-client-constrained-execution/SKILL.md` — both flowcharts and supporting prose
+
+**Step 1: Update the NO-TDD flowchart**
+
+Find the `digraph no_tdd { ... }` block (around lines 44–76). Insert a `toss-fe-review` step between `ds-client-review` (after PASS) and `Typecheck + commit`. New flowchart structure:
+
+```
+"Start next task" → "Dispatch implementer" → "BLOCKED?"
+  yes → "HARD STOP (escalate)"
+  no → "Any .tsx?"
+    yes → "ds-client-review"
+      "Violations?"
+        yes → "Re-dispatch with violations" → "Round 2 exhausted?"
+          still failing → "HARD STOP (DS violations)"
+          no → "ds-client-review"
+        no → "toss-fe-review"
+          "BLOCK findings?"
+            yes → "Re-dispatch with toss findings" → "Round 2 exhausted (toss)?"
+              still failing → "HARD STOP (toss BLOCK)"
+              no → "toss-fe-review"
+            no → "Collect SUGGEST/INFO for PR body" → "Typecheck + commit"
+    no → "Typecheck + commit"
+"Typecheck + commit" → "All tasks done?"
+  yes → "vercel-react-best-practices"
+  no → "Start next task"
+```
+
+Rewrite the digraph in DOT to match. (Keep it compact — don't over-state.)
+
+**Step 2: Update the TDD flowchart**
+
+Same insertion: between ds-client-review's PASS arrow and "Run tests (expect GREEN)", insert the toss-fe-review block. BLOCK findings re-dispatch implementer; SUGGEST/INFO collected. Then proceed to "Run tests (expect GREEN)" as before.
+
+**Step 3: Add a "Toss FE Review" subsection**
+
+After the existing "DS Client Review" section (around line 159), add:
+
+```markdown
+## Toss FE Review
+
+After ds-client-review passes (no violations), and before typecheck (NO-TDD)
+or before tests-green-verify (TDD), invoke the `toss-fe-review` agent using
+the Agent tool.
+
+**What to pass in the agent prompt:**
+1. The full content of each changed `.tsx` file (paste inline)
+2. (Optional) Adjacent files for context — parents, hook callers, sibling components — if the changed file references them in non-trivial ways
+3. Instruction: return structured findings per the agent's output format
+
+The agent reads its own rubric — do not paste rules inline.
+
+**Severity gate (orchestrator behavior):**
+- **BLOCK** finding(s) → re-dispatch implementer with the findings; same 2-round hard-stop rule as ds-client-review
+- **SUGGEST** / **INFO** → collect for the PR body's `## Toss FE notes` section; do NOT re-dispatch
+
+**Hard stop on toss BLOCK after 2 rounds:**
+
+1. Print: `TOSS FE REVIEW HARD STOP — unresolved BLOCK findings after 2 rounds`
+2. List every remaining BLOCK finding
+3. Stop. Do not move to the next task.
+4. Ask the user:
+   > How would you like to proceed?
+   > (a) Downgrade BLOCK to SUGGEST for this task — accept and move on
+   > (b) Adjust the task scope — break out the refactor into its own lane
+   > (c) Attempt one more round with new direction
+   > (d) Override — accept the smell and ship as-is
+
+Wait for explicit instruction.
+
+**SUGGEST / INFO collection:**
+
+Append SUGGEST findings to a `## Toss FE notes` section in the PR body
+under each lane's commit. INFO findings are not surfaced.
+```
+
+**Step 4: Trim wording across the file**
+
+Targets (current SKILL.md = 216 lines; target ~140 lines after trim):
+- "Common Mistakes" section (lines 207–217 currently): keep only items NOT redundant with flowchart labels. Likely keeps 3–4 bullets, drops the rest.
+- "Implementer Subagent" section (lines 139–149) and "Test-Writer Subagent" section (lines 151–158): consolidate into a single 4-line "Subagent Templates" subsection that points at `implementer-template.md` and `test-writer-template.md`. Drop the duplicated rule list.
+- "Detecting `.tsx` tasks" subsection (lines 38–40): merge into the flowchart's first step description; doesn't need its own heading.
+- Flowchart prose around the digraphs (e.g., lines 42–43, 78–79): trim to 1 sentence each.
+
+**Step 5: Commit**
+
+```bash
+git add .claude/skills/ds-client-constrained-execution/SKILL.md
+git commit -m "skill: wire toss-fe-review into per-task flow + trim wording
+
+Per-task flow becomes: implementer → ds-client-review → toss-fe-review
+→ typecheck → commit (NO-TDD); same insertion in TDD between ds-client-review
+and tests-green-verify.
+
+Severity gate: BLOCK re-dispatches implementer (2-round hard stop);
+SUGGEST/INFO collected for PR body. Conservative defaults prevent
+over-refactor loops.
+
+Trim: 'Common Mistakes' kept only non-redundant items; subagent
+sections collapsed to a 4-line pointer; flowchart prose tightened.
+Net: 216 → ~140 lines."
+```
+
+### Acceptance criteria
+- Both flowcharts have toss-fe-review inserted in the right place
+- "Toss FE Review" section exists, documents the severity gate + hard-stop
+- "DS Client Review" section no longer instructs caller to paste DS_CLIENT_USAGE.md
+- File length is < 160 lines
+- Run: `wc -l .claude/skills/ds-client-constrained-execution/SKILL.md` to verify
+
+---
+
+## Phase 8 — Update `HARNESS_DESIGN.md` + `AUTONOMOUS_PROTOCOL.md` (parallel-safe with Phase 9)
+
+### Task 8.1 — `HARNESS_DESIGN.md` updates
+
+**Files:**
+- Modify: `docs/plans/client-migration/HARNESS_DESIGN.md`
+
+**Step 1: Add "consult on demand" disclaimer at top**
+
+Insert after line 3 (after the `Locked decisions from the grill session ...` line):
+
+```markdown
+> **For Claude:** This is a decisions reference doc, not a preflight load.
+> Consult on demand when (a) a harness decision is being challenged,
+> (b) a new phase is being planned, or (c) a mode-specific section is
+> referenced by a skill. Do NOT read end-to-end on every cold session.
+```
+
+**Step 2: Update the per-phase internal flow section**
+
+Find lines 51–60 (the "Execute" step). Replace the `[NO-TDD]` and `[TDD]` flow descriptions with:
+
+```markdown
+4. **Execute** — `ds-client-constrained-execution` skill. One skill with two modes:
+   - `[NO-TDD]` tasks: implementer → ds-client-review → toss-fe-review → typecheck → commit
+   - `[TDD]` tasks: test-writer (red) → implementer (green) → ds-client-review → toss-fe-review → tests-green-verify → refactor → typecheck → commit
+   - Final pass after all tasks: `vercel-react-best-practices`
+   - Manual UI review: invoke `review-ui-on-browser` skill before merge for any UI-touching lane (run `npm run dev` first)
+```
+
+**Step 3: Commit**
+
+```bash
+git add docs/plans/client-migration/HARNESS_DESIGN.md
+git commit -m "HARNESS_DESIGN: note consult-on-demand + new review pipeline
+
+- Top-of-doc disclaimer: not a preflight load; consult on demand
+- Per-phase flow updated to include toss-fe-review per task and
+  manual review-ui-on-browser before merge"
+```
+
+### Task 8.2 — `AUTONOMOUS_PROTOCOL.md` updates
+
+**Files:**
+- Modify: `docs/plans/client-migration/AUTONOMOUS_PROTOCOL.md`
+
+**Step 1: Add consult-on-demand disclaimer at top**
+
+Insert after line 3 (after the `_Authoritative reference ..._` italic line):
+
+```markdown
+> **For Claude:** This is operational reference. The cold-session protocol
+> in CLAUDE.md inlines the mode-detection logic from §10 — you do NOT need
+> to read this doc end-to-end on every session. Load specific sections
+> just-in-time per the mode you're in (Mode A → §3 + HARNESS phase flow;
+> Mode B → §3, §4; Mode C → `review-pr-queue` skill + §11; Mode D →
+> `ds-client-constrained-execution` skill; Mode E → §14 + HARNESS close-out).
+```
+
+**Step 2: Update §15 (Skills Referenced)**
+
+Find the table around line 622–636. Add three new rows:
+
+```markdown
+| `toss-fe-review` agent | Per-task code-quality review (readability/predictability/cohesion/coupling), inserted between ds-client-review and typecheck |
+| `review-ui-on-browser` | Manual visual UI review via Playwright CLI on a running dev server. Used in Mode C (PR review) and Mode D (post-task) — never in autonomous routines |
+```
+
+**Step 3: Note in §10 (Cold-Session Modes) that detection logic moved to CLAUDE.md**
+
+Find §10 around line 385. After the heading (line 385) and before "When you start a Claude Code session..." paragraph, insert:
+
+```markdown
+> **Detection logic now lives in `CLAUDE.md`.** This section remains as
+> the canonical reference for the modes themselves (mode flows, mode triggers).
+> The cold-session preflight in CLAUDE.md inlines the trigger-detection
+> rules so the session can route into a mode without reading this doc first.
+```
+
+**Step 4: Drop the deferred Playwright allowlist note**
+
+Search for any `visual-review` / Playwright allowlist mention in §9 (lines around 348–384). If present (we added one in earlier discussion drafts), remove it. If not present, no-op.
+
+Run: `grep -n -i 'visual-review\|playwright' docs/plans/client-migration/AUTONOMOUS_PROTOCOL.md`
+Expected: no matches related to allowlist additions.
+
+**Step 5: Commit**
+
+```bash
+git add docs/plans/client-migration/AUTONOMOUS_PROTOCOL.md
+git commit -m "AUTONOMOUS_PROTOCOL: consult-on-demand + register new agent + skill
+
+- Top-of-doc disclaimer pointing to CLAUDE.md inlined mode detection
+- §15: register toss-fe-review agent and review-ui-on-browser skill
+- §10: note that detection logic moved to CLAUDE.md (this section
+  remains as mode flow reference)
+- Confirm no stale visual-review / Playwright allowlist additions"
+```
+
+### Acceptance criteria
+- HARNESS_DESIGN.md has the consult-on-demand banner at the top
+- HARNESS phase flow lists toss-fe-review and review-ui-on-browser
+- AUTONOMOUS_PROTOCOL.md §15 lists the two new artifacts
+- AUTONOMOUS_PROTOCOL.md §10 notes mode detection is in CLAUDE.md
+- No stale visual-review allowlist references
+
+---
+
+## Phase 9 — Update `CLAUDE.md` preflight (parallel-safe with Phase 8)
+
+### Task 9.1 — Trim preflight + inline mode-detection logic
+
+**Files:**
+- Modify: `CLAUDE.md`
+
+**Step 1: Read current CLAUDE.md cold-session protocol**
+
+Run: `cat CLAUDE.md`
+
+Expected: ~30-line file with `### Cold-Session Startup` block (currently steps 1–4) and Mode A–E description deferred to AUTONOMOUS_PROTOCOL.
+
+**Step 2: Replace the cold-session protocol block**
+
+Find the current Cold-Session Startup section. Replace with:
+
+```markdown
+### Cold-Session Startup
+
+**Preflight** (run every cold session — minimal universal load):
+
+1. Read `docs/TODO.md` → find first unchecked entry under "## Client Migration"
+2. **DS symlink check** (Phase 0+): `ls -la ../KISA-website/client/node_modules/@umichkisa-ds/web` — if not `->` symlink, run `bash ../KISA-website/client/scripts/link-ds.sh` (requires DS `dist/`; run `pnpm build` first if missing)
+
+**Mode detection** (inlined from `AUTONOMOUS_PROTOCOL.md` §10 — do this without loading AP):
+
+Derive the phase folder: `docs/plans/client-migration/phase-<N>-<slug>/` (where `<N>-<slug>` matches the first unchecked phase in TODO).
+
+Then check repo state:
+
+| Signal | Mode |
+|---|---|
+| `audit.md` missing in phase folder | **Mode A** — Audit writing |
+| `audit.md` exists, `plan.md` missing | **Mode B** — Plan writing + issue generation |
+| Open PRs exist for `phase-<N>` (per `gh pr list --label phase-<N>`) | **Mode C** — PR review |
+| `plan.md` exists, open `needs-interactive` issues without linked PRs | **Mode D** — Interactive execution |
+| All lanes merged for the phase | **Mode E** — Phase close-out |
+
+**Propose, don't execute.** Say:
+> "I see [state summary]. Likely mode: **X**. Proceed with Mode X, or pick a different mode?"
+
+Wait for user confirmation. NEVER execute without explicit go-ahead.
+
+**Mode-specific lazy loads** (load only when mode is confirmed):
+
+| Mode | Load |
+|---|---|
+| A | `docs/plans/client-migration/HARNESS_DESIGN.md` (Per-Phase Internal Flow); `docs/plans/client-migration/AUTONOMOUS_PROTOCOL.md` §3 (issue template) |
+| B | `AUTONOMOUS_PROTOCOL.md` §3 (issue template), §4 (6-rule autonomous gate) |
+| C | `review-pr-queue` skill (handles its own loads) |
+| D | `ds-client-constrained-execution` skill (handles its own loads) |
+| E | `ds-phase-end-bump` skill; HARNESS_DESIGN.md "Phase close-out" section |
+
+`docs/DS_CODEBASE.md` is loaded only if the current task involves DS surface discovery (typically Mode A grill or Mode D when a new component is needed). Implementers in Mode D execution use `docs/DS_CLIENT_USAGE.md` instead.
+
+### Wrapping up a merged PR / lane
+
+Invoke `wrapping-up-pr`.
+
+### Closing a phase (Mode E)
+
+1. All subphase entries already ticked (per-PR `wrapping-up-pr` handles those)
+2. `pnpm build` + `pnpm typecheck` pass
+3. If `ds-fixes-log.md` has phase entries, invoke `ds-phase-end-bump`
+4. Tick the parent phase entry
+```
+
+**Step 3: Verify file is well-formed**
+
+Run: `cat CLAUDE.md | head -60`
+Expected: opens with `# umichkisa-ds — KISA Design System`, then `## Session Protocol`, then the new Cold-Session Startup. No leftover step references to HARNESS_DESIGN.md preload.
+
+**Step 4: Commit**
+
+```bash
+git add CLAUDE.md
+git commit -m "CLAUDE.md: trim preflight to minimal universal load + inline mode detection
+
+Old preflight: TODO → HARNESS (full) → symlink → DS_CODEBASE.
+New preflight: TODO → symlink. Mode-detection logic inlined from AP §10
+(table-form so the session can route into a mode without preloading AP).
+Mode-specific docs lazy-loaded only when the mode is confirmed.
+
+Cuts cold-session context cost by ~40K tokens (HARNESS 265 lines + AP 700
+lines no longer auto-loaded). Preserves all behaviors via the lazy-load
+table — every mode pulls its own docs."
+```
+
+### Acceptance criteria
+- `CLAUDE.md` Cold-Session Startup block has TODO + symlink as the only auto-loaded items
+- Mode-detection table is present (5 modes, signals, lazy-load entries)
+- HARNESS_DESIGN.md and DS_CODEBASE.md are no longer in the preflight steps
+- "Wait for user confirmation" rule is explicit
+- Wrapping-up + Mode E sections are unchanged at the bottom
+
+---
+
+## Phase 10 — Verification
+
+### Task 10.1 — End-to-end SKILL.md flow review
+
+**Step 1: Read the updated SKILL.md end-to-end**
+
+Run: `cat .claude/skills/ds-client-constrained-execution/SKILL.md`
+
+Walk through it as if you're starting a new task. Confirm:
+- The flowchart is followable
+- Both NO-TDD and TDD paths are clear
+- The Toss FE Review section's severity gate is unambiguous
+- Hard-stop language is consistent across DS and Toss reviews
+- No leftover instruction to paste DS_CLIENT_USAGE.md inline anywhere
+- File length < 160 lines
+
+**Step 2: Cross-check that referenced files exist**
+
+```bash
+test -f .claude/agents/ds-client-review.md && echo "ds-client-review: ok"
+test -f .claude/agents/toss-fe-review.md && echo "toss-fe-review: ok"
+test -f .claude/skills/ds-client-constrained-execution/implementer-template.md && echo "implementer-template: ok"
+test -f .claude/skills/ds-client-constrained-execution/test-writer-template.md && echo "test-writer-template: ok"
+test -f .claude/skills/review-ui-on-browser/SKILL.md && echo "review-ui-on-browser: ok"
+test -f docs/DS_CLIENT_USAGE.md && echo "DS_CLIENT_USAGE: ok"
+test -f docs/DS_CODEBASE.md && echo "DS_CODEBASE: ok"
+```
+
+Expected: 7 lines of `: ok`.
+
+**Step 3: Confirm DS_CLIENT_USAGE.md has Part 1 / Part 2 structure**
+
+```bash
+grep -n "^## Part [12]" docs/DS_CLIENT_USAGE.md
+```
+
+Expected: two matches.
+
+```bash
+grep -n "^### " docs/DS_CLIENT_USAGE.md
+```
+
+Expected: includes "Available DS Surface", "Tier Picker", "What to Use" (Part 1) plus the Part 2 sections.
+
+**Step 4: DS-side build + typecheck (sanity — no code changes, but make sure docs/skills don't break a tooling check)**
+
+```bash
+cd /Users/jiohin/Desktop/KISA/DevTeam/dev/umichkisa-ds
+pnpm build
+pnpm typecheck
+```
+
+Expected: both green.
+
+**Step 5: Commit any final adjustments + push**
+
+If verification surfaces gaps (e.g., a referenced section doesn't exist, a flowchart label is wrong), fix them with one final commit:
+
+```bash
+git add -A
+git commit -m "verify: harness improvements end-to-end pass"
+```
+
+### Task 10.2 — Open PR
+
+**Step 1: Push branch**
+
+```bash
+git push -u origin harness-improvements-2026-04-25
+```
+
+**Step 2: Open PR**
+
+```bash
+gh pr create --title "Harness + ds-client-constrained-execution improvements (pre-Phase 3)" --body "$(cat <<'EOF'
+## Summary
+
+Tightens the ds-client-migration harness before Phase 3. Locked through grill-me on 2026-04-25.
+
+## Changes
+
+**Agents:**
+- `ds-client-review` reads `DS_CLIENT_USAGE.md` itself (dropped caller paste, ~3K tokens/round saved)
+- New `toss-fe-review` agent — per-task code-quality review (4 axes, BLOCK/SUGGEST/INFO severity)
+
+**Skills:**
+- `ds-client-constrained-execution` — wires `toss-fe-review` between `ds-client-review` and typecheck (both NO-TDD + TDD flows). Trim from 216 → ~140 lines.
+- New `review-ui-on-browser` — standalone manual skill, Playwright CLI, for visual UI review on running dev server. Not wired into autonomous routine (Vercel free-tier + auth constraints).
+
+**Docs:**
+- `DS_CLIENT_USAGE.md` restructured into Part 1 (write-time decision tree, available DS surface, tier picker, "what to use" rules, visibility/hierarchy rules absorbed from MEMORY) + Part 2 (full review-time rulebook with G1–G5 from Phase 2 evidence)
+- `DS_CODEBASE.md` — implementer pointer note redirects to DS_CLIENT_USAGE.md
+- `implementer-template.md` — pre-flight tier-justification checklist before "Your Job"
+- `HARNESS_DESIGN.md` + `AUTONOMOUS_PROTOCOL.md` — consult-on-demand banners; AP §15 registers new agent + skill
+- `CLAUDE.md` — preflight trimmed to TODO + symlink check + inlined mode-detection table; HARNESS / AP / DS_CODEBASE moved to lazy-load per mode
+
+## Test plan
+
+- [x] `pnpm build` green (DS-side)
+- [x] `pnpm typecheck` green (DS-side)
+- [x] `DS_CLIENT_USAGE.md` has Part 1 / Part 2 structure
+- [x] All seven referenced files exist after merge
+- [ ] Phase 3 audit (Mode A) is the first session that exercises the new preflight — sanity-check on next cold session
+- [ ] First Phase 3 lane that touches a `.tsx` exercises the new toss-fe-review per-task flow — verify behavior on the first run
+EOF
+)"
+```
+
+Return the PR URL.
+
+### Acceptance criteria
+- All seven artifacts confirmed present
+- DS_CLIENT_USAGE.md has Part 1 + Part 2
+- Build + typecheck green
+- PR opened against `main`
+
+---
+
+## Notes for executor
+
+- Work in the worktree at `/Users/jiohin/Desktop/KISA/DevTeam/dev/umichkisa-ds`
+- All commits use HEREDOC-style messages (per project convention)
+- Phases 3, 4, 5, 6 are parallelizable — dispatch concurrently if executing via `superpowers:subagent-driven-development`. Phases 7, 8, 9, 10 are gating in that order (8 + 9 may parallel, but both must finish before 10).
+- This PR has zero code changes — only docs / skills / agents. No tests required.
+- Avoid scope creep: do NOT also rewrite the Korean `toss-frontend-fundamentals` skill (the new `toss-fe-review` agent stands alone, fresh English prompt). Do NOT modify any client-side files.

--- a/docs/plans/client-migration/AUTONOMOUS_PROTOCOL.md
+++ b/docs/plans/client-migration/AUTONOMOUS_PROTOCOL.md
@@ -2,30 +2,19 @@
 
 _Authoritative reference for the ds-client-migration autonomous execution harness. Loaded alongside `HARNESS_DESIGN.md`. Read at the start of any client-migration session — particularly Modes C1/C2 (PR review) and Mode D (interactive execution) — per `CLAUDE.md` session protocol._
 
-> **For Claude:** This is operational reference. The cold-session protocol
-> in CLAUDE.md inlines the mode-detection logic from §10 — you do NOT need
-> to read this doc end-to-end on every session. Load specific sections
-> just-in-time per the mode you're in (Mode A → §3 + HARNESS phase flow;
-> Mode B → §3, §4; Mode C → `review-pr-queue` skill + §11; Mode D →
-> `ds-client-constrained-execution` skill; Mode E → §14 + HARNESS close-out).
+> **For Claude:** This is operational reference. CLAUDE.md inlines the cold-session
+> mode-detection logic — you do NOT read this doc end-to-end on every session.
+> Load only the slice for the confirmed mode (see CLAUDE.md lazy-load table).
 
-**Grill session:** 2026-04-17. All decisions locked in conversation; this doc is the artifact.
+**Grill session:** 2026-04-17. Subsequent amendments tracked in §15.
 
 ---
 
-## 1. Philosophy
+# Part 1 — Universal Reference
 
-This is a **ralph loop** with guardrails — the simplest thing that works, plus the minimum safety to keep a cloud-hosted agent from causing avoidable damage.
+## 1. Philosophy & Roles
 
-- **Task queue:** GitHub issues in the `umichkisa-ds` repo labeled `ds-client-migration`.
-- **Driver:** a Claude Code Routine running once per day at 02:00 KST (cloud-hosted, not on your local Mac).
-- **Executor:** a Claude Code agent inside the routine, one instance per lane, serial within the run.
-- **Output:** GitHub Pull Requests on the `KISA-website/client` and/or `umichkisa-ds` repos.
-- **Review:** always human, always live (raw GitHub for mechanical PRs, Claude-assisted session for redesigns / decisions).
-
-Guardrails exist to prevent: merging bad work, touching forbidden files, running away on compute, silently guessing at design decisions. Everything else trusts the agent to execute a well-specified lane.
-
-**Roles:**
+A **ralph loop** with guardrails: GitHub issues = task queue, a daily 02:00 KST cloud routine drains them serially, output is PRs, review is always human and live. Guardrails exist to prevent merging bad work, touching forbidden files, runaway compute, and silent design guesses. Everything else trusts the agent on a well-specified lane.
 
 | Actor | Role |
 |---|---|
@@ -34,39 +23,83 @@ Guardrails exist to prevent: merging bad work, touching forbidden files, running
 | Claude (autonomous routine) | Lane executor overnight, PR opener, `notes.md` appender, self-gated bailout |
 | GitHub | Issue queue, PR host, label-based state machine, CI runner, branch protector |
 
----
-
 ## 2. Label Taxonomy
 
-All migration-related issues and PRs use this label set. Labels are the primary state machine — no bespoke YAML, no custom state files.
+Labels are the state machine — no bespoke YAML, no custom state files.
 
 | Label | Purpose | Applied by |
 |---|---|---|
-| `ds-client-migration` | Master project label. Filters ALL migration work. | You at issue creation |
-| `phase-<N>` | Phase scope (e.g., `phase-0.5`, `phase-1`) | You at issue creation |
-| `lane:<id>` | Individual lane (e.g., `lane:0.5.4b`) | You at issue creation |
-| `autonomous-ready` | Issue is eligible for nightly routine pickup. Passed the 6-rule gate. | You at issue creation OR after bailout resolution |
-| `needs-interactive` | Issue must run in a live Claude session (not nightly). Mutually exclusive with `autonomous-ready`. | You at issue creation |
-| `blocked-by:<issue-#>` | Dependency edge. Issue is blocked until referenced issue is closed. | You at issue creation |
-| `needs-decision` | Bailout marker: autonomous Claude hit ambiguity, draft PR has a structured question block. | Autonomous Claude |
-| `routine-errored` | Routine run itself errored (network, tool error, timeout). WIP draft PR may exist. | Autonomous Claude |
-| `ready-for-review` | Autonomous Claude opened PR as non-draft, CI green, self-gates passed. | Autonomous Claude |
-| `needs-revision` | You requested revisions on an otherwise-ready autonomous PR. Next nightly routine picks up. | You during PR review |
+| `ds-client-migration` | Master project label | You at issue creation |
+| `phase-<N>` | Phase scope | You at issue creation |
+| `lane:<id>` | Individual lane | You at issue creation |
+| `autonomous-ready` | Eligible for nightly routine. Passed §6 gate. | You at issue creation OR after bailout resolution |
+| `needs-interactive` | Must run live in Mode D. Mutex with `autonomous-ready`. | You at issue creation |
+| `blocked-by:<issue-#>` | Dependency edge | You at issue creation |
+| `needs-decision` | Bailout: routine hit ambiguity; draft PR has question block | Autonomous Claude |
+| `routine-errored` | Routine itself errored (network, tool, timeout) | Autonomous Claude |
+| `ready-for-review` | PR opened non-draft, CI green, self-gates passed | Autonomous Claude |
+| `needs-revision` | You requested revisions on a `ready-for-review` PR | You during PR review |
 
-**Mutual exclusions:** `autonomous-ready` vs `needs-interactive` (one or the other, never both). `ready-for-review` vs `needs-decision` vs `routine-errored` (one of three on any open autonomous PR).
+**Mutex:** `autonomous-ready` ⊕ `needs-interactive`. `ready-for-review` ⊕ `needs-decision` ⊕ `routine-errored`.
 
-**End-state labels are removed post-merge.** The labels `ready-for-review`, `needs-decision`, `routine-errored`, and `needs-revision` are only meaningful while the PR is open — once merged, the PR's closed state replaces them. Strip them as part of the merge step (see §8).
+**End-state labels** (`ready-for-review`, `needs-decision`, `routine-errored`, `needs-revision`) are stripped at merge — closed PR state replaces them.
+
+## 3. Mode Definitions
+
+Six modes, detected per the CLAUDE.md preflight table. Cold session: Claude proposes mode, you confirm, Claude proceeds. **Never execute without explicit go-ahead.**
+
+| Mode | Trigger | Flow |
+|---|---|---|
+| **A. Audit** | `audit.md` missing | Grill-me → write `audit.md` → wait. Loads §5. |
+| **B. Plan + issues** | `audit.md` exists, `plan.md` missing | Grill (light) → write `plan.md` → generate per-lane issues per §5 → apply labels per §6 → wait. Loads §5, §6. |
+| **C1. PR review (ready)** | Sitting PR; no `needs-decision` / `needs-interactive` label, CI green | `review-pr-queue` → user picks → Claude `git fetch origin && git checkout <pr-branch>` in `../KISA-website/client/` (main clone) → "checked out, review when ready" → wait silently → on "good" → `wrapping-up-pr`. On feedback: see §3.1. |
+| **C2. PR review (interactive)** | Sitting PR with `needs-decision` or `needs-interactive` label | Same checkout → live discussion (grill-me / ui-ux-pro-max / systematic-debugging) → resolve → fix on branch → `wrapping-up-pr`. |
+| **D. Interactive execution** | `plan.md` exists; open `needs-interactive` issue without linked PR, OR user override | Wave lane menu (annotated per §11) → user picks → worktree at `../KISA-website/client/.worktrees/<lane-id>/` off `origin/dev` → `ds-client-constrained-execution`. |
+| **E. Phase close-out** | All lanes merged | Check `ds-fixes-log.md`; run `ds-phase-end-bump` if entries; tick phase in TODO.md. |
+
+### 3.1 Feedback during review (C1/C2)
+
+- **Default — fix on the same branch.** Bugfixes, copy/styling tweaks, prop renames, single-file scope, anything inside the lane's stated audit scope. Commit + push to the PR branch.
+- **Defer to a new lane** (propose, wait for confirm) when the fix touches files outside the lane's audit scope, OR requires a DS change (`ds-fix-during-migration`), OR adds a new feature/component not in the lane.
+
+  Phrasing: "This is out of scope for [lane-id] (reason: …). Defer to a new lane, or stretch this PR's scope?"
+
+### 3.2 Parallel-terminal safety
+
+User runs Mode C and Mode D in different terminals concurrently. Isolation:
+
+- **Mode C** → main client clone (`../KISA-website/client/`). One PR at a time.
+- **Mode D** → nested worktree (`../KISA-website/client/.worktrees/<lane-id>/`) off `origin/dev`.
+
+The two never touch the same working directory.
+
+## 4. Skills Index
+
+| Skill | Purpose |
+|---|---|
+| `grill-me` | Audit + plan grill (Modes A, B) |
+| `ds-client-constrained-execution` | Lane execution (autonomous + Mode D) |
+| `ds-fix-during-migration` | Mid-lane DS fixes |
+| `ds-phase-end-bump` | Mid-phase + phase-end DS version bump + publish |
+| `using-git-worktrees` | Mode D worktree setup |
+| `wrapping-up-pr` | Post-merge close-out (every merge path) |
+| `review-pr-queue` | Mode C1/C2 PR queue dispatcher |
+| `ui-ux-pro-max` | Visual/design critique in C2 |
+| `systematic-debugging` | C2 / `routine-errored` diagnosis |
+| `vercel-react-best-practices` | Final lane pass (per HARNESS) |
+| `toss-frontend-fundamentals` | Code-quality review (readability/predictability/cohesion/coupling), between ds-client-review and typecheck |
+| `review-ui-on-browser` | Manual visual review via Playwright CLI on dev server (C/D only, never autonomous) |
 
 ---
 
-## 3. Issue Template
+# Part 2 — Planning Slice (Modes A/B)
 
-Every lane gets exactly one GitHub issue. Issues are generated at audit/plan time from `plan.md` — one-to-one mapping. Issues are the single input to autonomous execution.
+## 5. Issue Template
 
-### Template
+Every lane = one issue, generated at plan-writing from `plan.md`. Issues are the sole input to autonomous execution.
 
 ```markdown
-# [Lane <lane-id>] <short lane title>
+# [Lane <lane-id>] <short title>
 
 ## Scope tag
 `[MECHANICAL|POLISH|REDESIGN]` `[TDD|NO-TDD]`
@@ -81,36 +114,34 @@ Every lane gets exactly one GitHub issue. Issues are generated at audit/plan tim
 - (or: no dependencies)
 
 ## Context
-One-paragraph why: link to relevant `audit.md` section, reference `DS_CLIENT_USAGE.md` if relevant, note design decisions locked in grill that bear on this lane.
+One paragraph: link to `audit.md` section, reference `DS_CLIENT_USAGE.md`, note locked design decisions.
 
 ## Acceptance criteria
-- [ ] <concrete, verifiable criterion 1>
-- [ ] <concrete, verifiable criterion 2>
+- [ ] <concrete criterion>
 - [ ] `typecheck` passes
-- [ ] No DS client constraint violations per `ds-client-review`
-- [ ] (if TDD) specified tests pass; `.skip` tests documented
+- [ ] No DS client-constraint violations per `ds-client-review`
+- [ ] (if TDD) tests pass; `.skip` documented
 - [ ] (if redesign) visual diff acceptable on Vercel `dev` preview
 
 ## Non-goals (do not touch)
-- <explicit out-of-scope file or concern>
-- <another>
+- <out-of-scope file or concern>
 
 ## Execution skill
 `ds-client-constrained-execution` — NO-TDD mode  *(or TDD mode)*
 
 ## Bailout triggers
-Stop with a `needs-decision` comment if:
-- A DS token is missing for a required class swap
-- A behavior cannot be replicated within the scope constraints
-- Any file outside the `## Files` list is about to be edited
-- Tests fail in ways the spec does not anticipate
-- <lane-specific trigger>
+Stop with `needs-decision` if:
+- DS token missing for required class swap
+- Behavior cannot be replicated within scope
+- Any file outside `## Files` is about to be edited
+- Tests fail in unanticipated ways
+- <lane-specific>
 
 ## Budget
-<N> minutes (typical lane ~30 min; 90 min hard cap)
+<N> minutes (typical ~30 min; 90 min hard cap)
 
 ## Expected diff summary
-~<N> files touched, ~<LoC> net change. If actual diff deviates significantly (e.g., 3x files), the agent should self-verify before opening PR.
+~<N> files, ~<LoC> net. If actual diff deviates 3x, self-verify before PR.
 
 ## Links
 - `docs/plans/client-migration/phase-<N>-<slug>/audit.md` — lane <id> section
@@ -118,622 +149,214 @@ Stop with a `needs-decision` comment if:
 - `packages/web/src/tokens/semantic.css`
 ```
 
-### Who writes issues
+You write all Phase N issues at plan-writing time (Mode B). Claude generates one-by-one from the plan; you review the issue list before any autonomous kickoff.
 
-**You (via Claude)** write all Phase N issues at plan-writing time (Mode B). Claude generates them one-by-one from the plan, you review the issue list as a whole before any autonomous kickoff.
+## 6. Autonomous-Readiness Gate (6 rules)
 
----
+A lane gets `autonomous-ready` iff ALL six hold:
 
-## 4. Autonomous-Readiness Gate (6-rule check)
+1. Scope tag is `[MECHANICAL]` or `[POLISH]` (not `[REDESIGN]`).
+2. All files in `## Files` are concrete — no "TBD" / "investigate" / "approximately".
+3. All design decisions touching the lane are locked in `## Context` or upstream audit.
+4. If `[TDD]`, test cases pre-specified in acceptance criteria; `.skip`s enumerated.
+5. No code touches: `src/app/api/**`, auth flow, routing middleware, `.env*`, credentials, package publish scripts.
+6. Lane is self-contained — no `package.json` / lockfile overlap with other currently-eligible lanes.
 
-Only issues that pass ALL six rules get the `autonomous-ready` label. Rules applied at label-assignment time; the label itself is the gate for the nightly routine.
+Non-passing lanes get `needs-interactive` → Mode D.
 
-### Rules
-
-A lane is autonomous-ready if and only if:
-
-1. **Scope tag is `[MECHANICAL]` or `[POLISH]`** (not `[REDESIGN]`).
-2. **All files listed in `## Files` are concrete** — no "TBD", no "needs investigation", no "approximately".
-3. **All design decisions touching this lane are locked** in the issue's `## Context` or an upstream audit doc. No open grill threads.
-4. **If `[TDD]`, the test cases are pre-specified** in acceptance criteria. `.skip` test cases are explicitly enumerated.
-5. **No code in this lane touches:** `src/app/api/**`, auth flow logic, routing middleware, `.env*` files, credentials, or package publish scripts.
-6. **Lane scope is self-contained** — doesn't require concurrent editing of files owned by another currently-eligible lane (no `package.json` / lockfile overlap with other `autonomous-ready` issues in the same window).
-
-### Non-passing lanes
-
-Get `needs-interactive` label. Execute via Mode D (live Claude session) using the regular `ds-client-constrained-execution` flow.
-
-### Re-labeling
-
-- A `needs-decision` draft PR's question, once you resolve it, may make the underlying lane autonomous-ready again → remove `needs-decision`, add `needs-revision`.
-- A `routine-errored` lane, once the root cause is cleared, may be re-queued by removing the error label.
+**Re-labeling:** when a `needs-decision` PR's question is resolved, remove `needs-decision`, add `needs-revision`; the next routine revises and re-opens non-draft.
 
 ---
 
-## 5. Routine
+# Part 3 — Autonomous Routine Reference
 
-### Cadence
+## 7. Routine Algorithm
 
-**Once per day, 02:00 KST.** Cloud-hosted Claude Code Routine (does not require local Mac).
+**Cadence:** once per day, 02:00 KST. Cloud-hosted Claude Code Routine (no local Mac required).
 
-### Algorithm
+Per run:
 
-```
-02:00 KST — Routine fires
-  │
-  ▼
-Query eligible issues:
-  gh issue list \
-    --repo <target-repo> \
-    --label ds-client-migration \
-    --label phase-<currentPhase> \
-    --label autonomous-ready \
-    --state open
-  │
-  ▼
-Filter out any issue with a still-open `blocked-by:<X>` label
-  │
-  ▼
-Filter out any issue whose linked PR is already open
-  (prevents double-claiming lanes picked up in live Mode D)
-  │
-  ▼
-Sort: oldest issue creation time first
-  │
-  ▼
-For each eligible issue (until 4h total cap):
-  │
-  ├─ Read issue spec (template sections)
-  ├─ `git fetch origin dev`
-  ├─ `git checkout -b ds-client-migration/phase-<N>/<lane-id>-<slug> origin/dev`
-  ├─ Execute per `## Execution skill` (ds-client-constrained-execution)
-  │   ├─ Respect `## Files` list; bailout if scope drift
-  │   ├─ Respect `## Non-goals`; bailout if touched
-  │   ├─ Apply `## Bailout triggers`; bailout per AP-Q2 if hit
-  │   ├─ Run typecheck + build + ds-client-review
-  │   └─ (if TDD) run tests; `.skip` counts as pass
-  ├─ Check `## Expected diff summary`; self-sanity-check before PR
-  ├─ `git push -u origin <branch>`
-  ├─ `gh pr create` with title `[Phase <N> / <lane-id>] <scope>: <summary>`
-  ├─ Auto-generated PR body (see §7)
-  ├─ Apply PR labels: `ds-client-migration`, `phase-<N>`, `lane:<id>`, end-state label
-  ├─ Append one-line entry to phase's `notes.md` (commit to same branch)
-  └─ Tag originating issue with `done` label? (optional — PR merge closes issue)
-  │
-  └─ Hard cap: 90 min per lane. If exceeded:
-       ├─ `git commit -m "wip: partial work, bailing to human"`
-       ├─ `git push`
-       ├─ `gh pr create --draft` with `routine-errored` label
-       └─ Move to next lane
-  │
-  ▼
-Total run cap: 4h. Remaining eligible lanes wait for tomorrow.
-```
+1. `gh issue list --label ds-client-migration --label phase-<N> --label autonomous-ready --state open` in target repo.
+2. Filter out issues with open `blocked-by:<X>` or already-linked open PR (prevents collisions with live Mode D).
+3. Sort oldest-first.
+4. For each, until 4h cap: read spec → `git fetch origin dev` → `git checkout -b ds-client-migration/phase-<N>/<lane-id>-<slug> origin/dev` → execute via `ds-client-constrained-execution` → push → `gh pr create` → apply labels → append one line to `notes.md`.
+5. Per-lane 90 min hard cap → commit WIP, draft PR with `routine-errored`, next lane.
 
-### Caps
+**Caps:** 90 min/lane, 4h/run, 1 lane in flight at a time (serial).
 
-| Cap | Value | Rationale |
+**Trigger:** `schedule` skill or `CronCreate`. Target repo: usually `KISA-website/client`; for DS-side lanes (e.g., 0.5.2), `umichkisa-ds`.
+
+## 8. Bailout Protocol
+
+Autonomous Claude does **not guess**. It commits WIP as a draft PR, documents the blocker, stops.
+
+| Trigger | Action | PR label |
 |---|---|---|
-| Per-lane time | 90 minutes | Prevents runaway compute on a pathological case |
-| Per-run total time | 4 hours | Bounds nightly cost; leaves buffer before morning |
-| Concurrency within a run | 1 (serial) | Simpler; no wall-clock pressure at 02:00 |
+| Clean completion, CI green | Non-draft PR | `ready-for-review` |
+| DS gap discovered | Run `ds-fix-during-migration`; continue | — |
+| Spec ambiguity | Commit WIP, draft PR + question block, stop | `needs-decision` |
+| File scope drift (touched outside `## Files`) | Commit WIP before drift, draft PR, stop | `needs-decision` |
+| Tests fail unexpectedly | Commit WIP + test output, draft PR, stop | `needs-decision` |
+| 90 min lane cap | Commit WIP + progress summary, draft PR, stop | `routine-errored` |
+| Tool/network/token error | Attempt commit WIP; draft PR if any progress | `routine-errored` |
 
-### Trigger mechanism
-
-Set up via `schedule` skill or `CronCreate` tool. Target repo: the one where lanes execute (primarily `KISA-website/client`; for Phase 0.5.2 and similar DS-side lanes, target is `umichkisa-ds`).
-
----
-
-## 6. Bailout Protocol
-
-When autonomous Claude cannot complete a lane cleanly, it does **not guess**. It commits what it has as a draft PR, documents the blocker, and stops.
-
-### States and transitions
-
-| Trigger | Action | Label on PR |
-|---|---|---|
-| Clean completion, CI passes | Non-draft PR, issue unchanged | `ready-for-review` |
-| DS gap discovered | Run `ds-fix-during-migration` mid-lane; continue if resolved | — (transparent fix) |
-| Spec ambiguity | Commit WIP, open draft PR with structured question block, stop | `needs-decision` |
-| File scope drift (attempted edit outside `## Files`) | Commit WIP before drift, open draft PR, stop | `needs-decision` |
-| Tests fail unexpectedly | Commit WIP with test output, open draft PR, stop | `needs-decision` |
-| Per-lane 90 min cap | Commit WIP, open draft PR with progress summary, stop | `routine-errored` |
-| Tool error / network failure / out of tokens | Attempt commit WIP; open draft PR if any progress | `routine-errored` |
-
-### `needs-decision` PR body structure
+### `needs-decision` PR body
 
 ```markdown
 Closes #<issue-number>
 
 ## 🤔 Needs decision
 
-**Stuck on:** <one-line summary of the ambiguity>
+**Stuck on:** <one-line summary>
 
-**What I attempted:**
-<factual description of work done so far>
+**What I attempted:** <factual description>
 
-**What's unclear:**
-<specific question>
+**What's unclear:** <specific question>
 
 **Options:**
-1. <concrete option>  — tradeoff: ...
-2. <concrete option>  — tradeoff: ...
-3. <concrete option>  — tradeoff: ...
+1. <option> — tradeoff: …
+2. <option> — tradeoff: …
 
-**My weak preference:** Option N, because ...
+**My weak preference:** Option N, because …
 
 ## Current state
-Branch: `<branch-name>`
-Files changed: <list>
-CI: <status>
+Branch: `<branch-name>` · Files: <list> · CI: <status>
 
-Resolve by leaving a comment with the chosen option and (if needed) additional spec. Remove `needs-decision`, add `needs-revision` — next nightly routine will revise and re-open as non-draft.
+Resolve by leaving a comment with the chosen option. Remove `needs-decision`, add `needs-revision` — next routine revises.
 ```
 
 ### Resolution flow
 
-1. You read the draft PR + question block
-2. Leave a PR comment with the decision ("Go with option 2")
-3. Apply `needs-revision` label, remove `needs-decision`
-4. Next 02:00 routine revises (per AP-Q14 below)
-5. PR becomes `ready-for-review`
-6. You merge
+You read draft + question → leave decision comment → swap `needs-decision` → `needs-revision` → next 02:00 routine revises (per §13) → PR becomes `ready-for-review` → you merge.
 
----
+## 9. Permission Scope (Autonomous)
 
-## 7. PR & Branch Conventions
+### Allowed (full)
+- `Edit`, `Write`, `Read`, `Grep`, `Glob`
+- `Agent` (skills, review agents)
+- `WebFetch`, `WebSearch` (read-only ref docs)
 
-### Branch naming
-
-```
-ds-client-migration/phase-<N>/<lane-id>-<short-slug>
-```
-
-Example: `ds-client-migration/phase-0.5/0.5.4b-navmenu-retokenize`
-
-Branches off `dev`. Merged via PR. Squash-merge deletes the branch.
-
-### PR title
-
-```
-[Phase <N> / <lane-id>] <scope>: <one-line summary>
-```
-
-Example: `[Phase 0.5 / 0.5.4b] NavMenu: retokenize + drop framer-motion`
-
-### PR body (auto-generated by autonomous Claude)
-
-```markdown
-Closes #<issue-number>
-
-## Summary
-<1-2 sentences>
-
-## Changes
-- `path/to/file1`: <what changed>
-- `path/to/file2`: <what changed>
-
-## Verification
-- [x] typecheck passed
-- [x] ds-client-review passed (no violations)
-- [x] (if TDD) <M> tests pass, <K> tests `.skip`'d (documented)
-- [x] build passed
-
-## Scope tag
-`[POLISH]` `[NO-TDD]` — matches issue spec
-
-## Notes
-<anything worth flagging for reviewer; empty if nothing>
-```
-
-### Merge strategy
-
-**Squash-merge, one commit per PR.** Feature branch deleted on merge.
-
-### Labels on PR
-
-Mirror issue labels at PR open time. Add end-state label (`ready-for-review` / `needs-decision` / `routine-errored`).
-
----
-
-## 8. Merge Authority
-
-**Human-only merge.** No auto-merge, regardless of scope tag or CI status.
-
-**Branch protection on `dev`:**
-- Require status checks to pass before merge (typecheck, build, ds-client-review bot if configured)
-- Require 1 approval (your self-approval)
-- No direct pushes; all work via PR
-- Auto-delete head branches on merge
-
-Autonomous Claude opens PRs but never merges. You are the sole merge authority.
-
-**Merge close-out:** invoke `wrapping-up-pr` for every merge path (single PR, batch, revision-flow auto-merge, superseding PR, Mode D direct push).
-
----
-
-## 9. Permission Scope (Autonomous Session)
-
-Autonomous agents run under **restricted scope**. These are constraints passed to the routine's Claude session.
-
-### Allowed tools (full access)
-
-- `Edit`, `Write`, `Read`, `Grep`, `Glob` — all file operations within scope
-- `Agent` — for invoking skills and review agents
-- `WebFetch`, `WebSearch` — read-only; reference docs (React, Tailwind, shadcn, Radix, lucide)
-
-### `Bash` — allowlisted commands only
-
-- `pnpm` / `npm` subcommands: `build`, `test`, `typecheck`, `install` (no-arg, lockfile sync only)
-- `gh` CLI: `pr create`, `pr view`, `pr edit`, `issue view`, `issue edit`, `issue list`, `issue comment`
-- `git`: `fetch`, `checkout` (new branch), `add`, `commit`, `push` (feature branch only), `status`, `diff`, `log`
-- `tsc --noEmit`
-- `ls`, `cat` (read-only utilities, narrow use)
+### `Bash` allowlist
+- `pnpm`/`npm`: `build`, `test`, `typecheck`, `install` (no-arg lockfile sync only)
+- `gh`: `pr create`, `pr view`, `pr edit`, `issue view`, `issue edit`, `issue list`, `issue comment`
+- `git`: `fetch`, `checkout` (new branch), `add`, `commit`, `push` (feature branch), `status`, `diff`, `log`
+- `tsc --noEmit`, `ls`, `cat`
 
 ### Hard-denied
-
 - `rm -rf`, `git reset --hard`, `git push --force`, `git clean -fd`
 - `npm publish`, `pnpm publish`
 - Any command touching `.env*`, `~/.ssh/`, `~/.config/gh/`, credentials
-- `killall`, system-level ops, sudo
+- `killall`, sudo, system-level ops
 
-### Scope constraints (soft — enforced by agent discipline + audit)
+### Soft (agent discipline + audit)
+- Edit only files in `## Files`; bailout otherwise
+- No new dependencies (only `[MECHANICAL]` lanes tagged `dependency-change`, which are `needs-interactive` anyway)
+- No `package.json` version / tag / release edits
 
-- Only edit files listed in the issue's `## Files` section; bailout otherwise
-- Do not install new dependencies (only `[MECHANICAL]` lanes tagged `dependency-change` may do so, and those are `needs-interactive`)
-- Do not modify `package.json` version, tags, or releases
+**Trust ramp:** Phase 0.5 runs under this scope. After 3 phases without an autonomous-caused incident, scope may be expanded — deliberate amendment, not implicit.
 
-### Trust ramp
+## 10. PR & Branch Conventions
 
-Phase 0.5 runs under this restricted scope. After 3 completed phases without an autonomous-caused incident, the scope may be expanded to allow a broader `Bash` allowlist. Escalation is a deliberate protocol amendment, not implicit.
+**Branch:** `ds-client-migration/phase-<N>/<lane-id>-<short-slug>`, off `dev`, squash-merged, deleted on merge.
 
----
+**PR title:** `[Phase <N> / <lane-id>] <scope>: <summary>`
 
-## 10. Cold-Session Modes (CLAUDE.md Session Protocol)
+**PR body:** auto-generated by `ds-client-constrained-execution` (see skill); always opens with `Closes #<issue>` and includes `## Summary` / `## Changes` / `## Verification` / `## Scope tag` / `## Notes`.
 
-> **Detection logic now lives in `CLAUDE.md`.** This section remains as
-> the canonical reference for the modes themselves (mode flows, mode triggers).
-> The cold-session preflight in CLAUDE.md inlines the trigger-detection
-> rules so the session can route into a mode without reading this doc first.
+**Labels on PR:** mirror issue labels at open + add end-state label.
 
-When you start a Claude Code session and say "pick up the task," the cold-session protocol detects repo state and proposes one of six modes (A, B, C1, C2, D, E). You confirm; Claude proceeds.
-
-### Detection
-
-On startup (post-HARNESS check and DS symlink check):
-
-1. Read `docs/TODO.md` → find current phase (first unchecked under "## Client Migration")
-2. Locate phase folder: `docs/plans/client-migration/phase-<N>-<slug>/`
-3. Query repo state:
-   - Does `audit.md` exist?
-   - Does `plan.md` exist?
-   - `gh pr list --label ds-client-migration --label phase-<N> --state open` — any sitting PRs?
-   - `gh issue list --label ds-client-migration --label phase-<N> --state open` — any open issues? (indicates work not yet done)
-
-### Mode selection
-
-| Mode | Trigger | Flow |
-|---|---|---|
-| **A. Audit writing** | `audit.md` missing | Grill-me session → write `audit.md` → wait for go-ahead |
-| **B. Plan writing + issue generation** | `audit.md` exists, `plan.md` missing | Grill (minor, as needed) → write `plan.md` → generate per-lane GitHub issues per §3 → apply labels → wait for go-ahead to enable routine |
-| **C1. PR review — ready-to-merge** | Sitting PR(s); selected PR has neither `needs-decision` nor `needs-interactive` label, CI green | `review-pr-queue` → user picks → Claude `git fetch origin && git checkout <pr-branch>` in `../KISA-website/client/` (main clone) → Claude says "checked out, review when ready" and waits silently → user does local visual review → on "good" → `wrapping-up-pr`. If user gives feedback, see *Feedback during review* below. |
-| **C2. PR review — interactive/decision** | Sitting PR(s); selected PR has `needs-decision` or `needs-interactive` label | Same checkout flow as C1 → live discussion (grill-me / ui-ux-pro-max / systematic-debugging as needed) to resolve the pending question or judgment call → fix on branch → on "good" → `wrapping-up-pr`. |
-| **D. Interactive execution** | `plan.md` exists, open `needs-interactive` issues without linked PRs, OR user overrides to execute live | Present wave lane menu (annotated per §12); user picks; **create worktree off `dev` at `../KISA-website/client/.worktrees/<lane-id>/`** (nested, gitignored — keeps Mode D isolated from any parallel Mode C in the main clone) → `ds-client-constrained-execution`. |
-| **E. Phase close-out** | All lanes merged, phase marked ready | Check `ds-fixes-log.md` for phase entries; run `ds-phase-end-bump` if any; tick phase in TODO.md |
-
-#### Feedback during review (C1/C2)
-
-When the user gives feedback on a checked-out PR:
-
-- **Default — fix on the same branch.** Bugfixes, copy/styling tweaks, prop renames, single-file scope, anything inside the lane's stated audit scope. Commit and push to the same PR branch.
-- **Defer to a new lane** (propose, wait for confirm) when the fix:
-  - touches files outside the lane's audit scope, OR
-  - requires a DS change (then `ds-fix-during-migration` flow), OR
-  - adds a new feature/component not in the original lane.
-
-  Phrasing: "This feedback is out of scope for [lane-id] (reason: …). Defer to a new lane, or stretch this PR's scope?" Wait for explicit user choice.
-
-#### Parallel-terminal safety
-
-User may run Mode C and Mode D in different terminals at the same time. Isolation rule:
-
-- **Mode C uses the main client clone** (`../KISA-website/client/`) — checks out PR branches there. User reviews one PR at a time, so no internal collision.
-- **Mode D uses worktrees** under `../KISA-website/client/.worktrees/<lane-id>/`, always branched off `origin/dev`.
-
-This way the two modes never touch the same working directory.
-
-### Protocol
-
-1. Claude detects state and says:
-   > "I see [state summary]. Likely mode: **X**. Proceed with Mode X, or do you want a different mode (list available)?"
-2. You confirm or redirect.
-3. Claude proceeds per the confirmed mode.
-4. NEVER execute without explicit go-ahead (per CLAUDE.md rule).
+**Merge:** human-only, no auto-merge regardless of scope tag or CI. Branch protection on `dev` requires status checks (typecheck, build, ds-client-review), 1 approval, no direct pushes, auto-delete head branches. Autonomous opens PRs, never merges. Every merge path (single, batch, revision auto-merge, superseding, Mode D direct push) closes with `wrapping-up-pr`.
 
 ---
 
-## 11. Daily Review Workflow (`review-pr-queue` Skill)
+# Part 4 — Operational Reference (Live Sessions)
 
-_Status: spec'd below, implementation pending. To be created as a Claude Code skill in `docs/plans/client-migration/phase-0.5-layout/` or as a shared skill in `.claude/skills/review-pr-queue/`._
+## 11. Lane State (Single Source of Truth)
 
-### Purpose
-
-When you start your daily availability window, this skill fetches all open autonomous PRs for the current phase and presents them grouped by required review effort, with direct links.
-
-### Input
-
-`--phase <N>` (defaults to current phase from TODO.md)
-
-### Output
-
-```markdown
-### Today's PR queue (phase-0.5) — 5 open
-
-✅ **Ready-to-merge / C1 (3)** — CI green, no decisions pending
-- [MECHANICAL] #43 [0.5.4a] Header cleanup — https://github.com/.../pull/43
-- [POLISH]     #44 [0.5.4f] MobileMenuButton — https://github.com/.../pull/44
-- [POLISH]     #45 [0.5.5]  Footer — https://github.com/.../pull/45
-
-🧐 **Needs interactive review / C2 (2)** — `needs-decision` / `needs-interactive` label
-- [REDESIGN][needs-interactive]  #46 [0.5.4e] UserInfo (Avatar-only) — https://github.com/.../pull/46
-- [needs-decision]               #47 [0.5.4b] NavMenu (draft) — https://github.com/.../pull/47
-    ↳ Question: "Should backdrop-blur be kept at 90% opacity or 80%?"
-
-⚠️ **CI failing (0):** none
-
-📝 **Needs revision (0):** none
-
----
-Pick a PR number to start with.
-```
-
-### Skill responsibilities
-
-1. Run `gh pr list` with phase + migration labels.
-2. Classify each PR: `needs-decision` or `needs-interactive` label → C2; else CI-green → C1; CI-failing or `needs-revision` → separate buckets.
-3. For C2 PRs, pull the question block from the PR body.
-4. Present compact menu (numbers + URLs only — no "open in browser" or `gh pr merge` suggestions; user reviews locally).
-5. On user pick:
-   1. `cd ../KISA-website/client/ && git fetch origin && git checkout <pr-branch>` (main clone — Mode C never uses worktrees).
-   2. **C1:** print "Branch checked out at `<branch>` in `../KISA-website/client/`. Review when ready." Then wait silently. On user "good" → `wrapping-up-pr`. On feedback → apply *Feedback during review* rule (§10).
-   3. **C2:** print the same checkout confirmation, then surface the pending question / decision context and enter live discussion (grill-me / ui-ux-pro-max / systematic-debugging as needed).
-
-### When invoked
-
-- Automatically suggested by Mode C cold-session detection
-- Manually via `/review-pr-queue` slash command
-
----
-
-## 12. Single Source of Truth (Lane State)
-
-**GitHub issues + their linked PRs are the authoritative lane state machine.** `plan.md` is the plan; `notes.md` is the breadcrumb trail; neither tracks execution state.
-
-### Issue states
+**GitHub issues + linked PRs are the authoritative lane state machine.** `plan.md` is the plan; `notes.md` is the breadcrumb trail; neither tracks execution state.
 
 | GitHub state | Meaning |
 |---|---|
-| Open, no linked PR | Lane **available** |
-| Open, linked draft PR | Lane **in-progress** (autonomous has it or user has it in worktree) |
-| Open, linked non-draft PR | Lane **awaiting review** |
-| Closed (via PR merge) | Lane **done** |
-| Closed (manually) | Lane **skipped** — dependents need their `blocked-by:<N>` removed |
+| Open, no linked PR | **available** |
+| Open, linked draft PR | **in-progress** (autonomous or live worktree) |
+| Open, linked non-draft PR | **awaiting review** |
+| Closed via PR merge | **done** |
+| Closed manually | **skipped** — dependents need `blocked-by:<N>` removed |
 
 ### Lane menu annotation (Mode D)
 
-Before presenting the wave lane menu, Claude queries:
+Before presenting the wave menu, query:
 
 ```sh
 gh issue list --repo <repo> --label ds-client-migration --label phase-<N> --state open \
   --json number,title,labels,linkedPullRequests
 ```
 
-And annotates each lane:
+Annotate:
 
 ```
-Wave 3 lanes — pick one:
+Wave 3 — pick one:
   ✗ 0.5.4b — PR #42 open (autonomous claimed last night)    ← DO NOT PICK
-  ✗ 0.5.4d — PR #43 open (autonomous claimed last night)    ← DO NOT PICK
   ○ 0.5.4e — available                                       ← PICKABLE
-  ○ 0.5.4f — available                                       ← PICKABLE
-  ✓ 0.5.5  — done (merged yesterday)                         ← SKIP
+  ✓ 0.5.5  — done                                            ← SKIP
 ```
 
-User picks only from `○` rows. Prevents collisions with overnight autonomous work.
+User picks only `○`. Autonomous routine runs the same check before claiming a lane (skips if open PR exists).
 
-### Autonomous routine's analogous check
+## 12. PR Review Comments (Revision Flow)
 
-Before executing a lane, the routine queries the same way. If the issue already has an open PR, skip — means interactive claimed it live.
-
----
-
-## 13. PR Review Comments (Revision Flow)
-
-When you review an autonomous PR and leave an actionable comment.
-
-### Your options per comment
-
-| Comment type | Action | Time to resolution |
+| Comment type | Action | Resolution |
 |---|---|---|
-| Trivial (typo, one-line fix) | Edit on GitHub or locally, commit, merge | Immediate |
-| Clear change request (larger) | Add `needs-revision` label, leave comment, go about day | Next 02:00 routine |
-| Design discussion | Open Claude session, live back-and-forth, resolve | Same session |
-| Out of scope for this lane | Comment "defer to separate issue/lane", merge PR as-is | Immediate |
+| Trivial (typo, one-liner) | Edit on GitHub or locally, commit, merge | Immediate |
+| Clear larger change | `needs-revision` label + comment, walk away | Next 02:00 routine |
+| Design discussion | Open Claude session, live back-and-forth | Same session |
+| Out of scope | Comment "defer to separate lane", merge as-is | Immediate |
 
-### Autonomous revision flow (when `needs-revision` label applied)
+### Autonomous revision flow (`needs-revision` set)
 
-Next 02:00 routine picks up `needs-revision` PRs **alongside** fresh eligible issues.
+Next 02:00 routine picks up `needs-revision` PRs alongside fresh issues. For each:
 
-For each `needs-revision` PR:
+1. Read unresolved review comments.
+2. Classify each: **Question** → reply, no code change, resolve. **Clear change** → new commit on same branch, push, reply "Applied in <commit>", resolve. **Ambiguous** → reply asking, keep open, ADD `needs-decision` (both labels = you decide). **Out of scope** → reply "belongs in lane X; suggest deferring. Confirm to merge-as-is or I bail."
+3. When all threads resolved/awaiting, remove `needs-revision`.
 
-1. Read all unresolved review comments
-2. Classify each:
-   - **Question** → reply in thread, no code change, mark thread resolved
-   - **Clear change request** → make change in a new commit on same branch, `git push`, reply "Applied in <commit>", mark thread resolved
-   - **Ambiguous** → reply asking for clarification, keep thread open, ADD `needs-decision` label (both labels present = you decide)
-   - **Out of scope** → reply "This belongs in lane X; suggest deferring. Confirm to merge-as-is or I'll bail."
-3. When all threads resolved or awaiting reply, remove `needs-revision` label.
+**Push discipline:** new commits on feature branch, NOT force-push. Squash-merge consolidates at merge.
 
-### Push discipline
+**Spec drift:** if a review comment contradicts the original issue spec, autonomous Claude says so: *"Issue spec says X. Your comment asks for Y. Update spec + do Y, or leave as-is per spec?"*
 
-New commits on the feature branch, NOT force-push. Squash-merge consolidates them when you merge.
+## 13. DS Fixes During Migration
 
-### Spec drift protection
+Two skills handle this. AP just covers project-specific scheduling rules.
 
-If your comment contradicts the original issue spec, autonomous Claude should say so:
-> "Issue spec says X. Your comment asks for Y. Should I update the spec + do Y, or leave as-is per spec?"
+### Mid-lane fix (`ds-fix-during-migration`)
 
----
+Triggered when a lane discovers a DS gap (missing token, component bug, registry omission). Skill handles: pause client lane → switch to DS repo → fix → `pnpm build` → npm-link picks up → log to `ds-fixes-log.md` → resume.
 
-## 14. DS Fixes During Migration
+Autonomous Claude may invoke only for scope-safe fixes: pure SVG additions to icon registry, missing variants on existing components with clear spec, token additions approved in prior grill. Unsafe (component restructure, breaking API change) → `needs-decision`.
 
-Two flows, both existing skills. No change from HARNESS design.
+### Mid-phase pre-consume bump (`ds-phase-end-bump`, fired mid-phase)
 
-### Mid-lane (during execution)
+When a client lane consumes a DS addition produced by an earlier lane in the same phase, the lockfile-pinned DS version predates the addition → consuming lane's CI typecheck fails. Insert a patch-bump lane between producer and consumer.
 
-Invoked when a lane discovers a DS gap (missing token, component bug, registry omission).
+- **Mid-phase bumps are always patch** (per memory: ALL DS bumps are patch).
+- Producer lane's PR must be merged to DS `main` first; verify the new symbol is in source (e.g., `packages/web/src/components/icon/registry.ts`).
+- Consumer lane depends on the bump lane via `blocked-by:<issue-#>`.
+- All bump lanes are `needs-interactive` (publish is hard-denied for autonomous per §9).
+- **Omission recovery:** if plan-writing missed it and the routine hits the gap (lane 0.5.5, 2026-04-18 precedent), the consuming lane bails `needs-decision` per §8; you run the bump interactively; relabel `needs-revision`; next routine finishes it.
 
-Skill: `ds-fix-during-migration`
+### Phase-end bump (`ds-phase-end-bump`, Mode E)
 
-Flow:
-1. Pause client lane work
-2. Switch to DS repo (same machine, different package dir)
-3. Fix DS component or token
-4. `pnpm build` in DS
-5. Verify via `npm link` symlink (client picks up new DS build automatically)
-6. Append to `docs/plans/client-migration/ds-fixes-log.md`
-7. Return to client lane, continue
-
-Autonomous Claude can invoke this skill only for fixes that are scope-safe:
-- Pure SVG additions to icon registry
-- Adding missing variants to existing components (with clear spec)
-- Token additions already approved in prior grill
-
-Scope-unsafe fixes (component restructure, breaking API change) → bailout to `needs-decision`.
-
-### Phase-end bump
-
-Invoked in Mode E (phase close-out).
-
-Skill: `ds-phase-end-bump`
-
-Flow:
-1. Check `ds-fixes-log.md` for phase's fixes
-2. Bump `@umichkisa-ds/web` version in `packages/web/package.json`
-3. Commit + tag `web-vX.Y.Z`
-4. Push tag → GitHub Actions publishes to npm
-5. Update `KISA-website/client/package.json` to pinned new version
-6. `npm install` in client
-7. Commit client version bump
-
-### Mid-phase pre-consume bump
-
-Invoked interactively when a client lane in the current phase **consumes** a DS addition (new component, new icon, new token) that was added by an earlier lane in the same phase. Without a bump between the producing DS lane and the consuming client lane, the client's lockfile-pinned DS version predates the addition, so the consuming lane's typecheck fails in CI even though DS `main` has the API.
-
-The bump is structurally identical to §14b (phase-end); it just fires earlier.
-
-Skill: `ds-phase-end-bump` (same skill, invoked mid-phase).
-
-Flow:
-1. Confirm the producing DS lane is merged to DS `main` and the addition is present in `packages/web/src/components/icon/registry.ts` (or the relevant source)
-2. Bump `@umichkisa-ds/web` **patch** version in `packages/web/package.json` (mid-phase bumps are always patch; minor/major bumps wait for phase end)
-3. Append to `docs/plans/client-migration/ds-fixes-log.md` with the "mid-phase" marker
-4. Commit + tag `web-vX.Y.Z`
-5. Push tag → GitHub Actions publishes to npm
-6. Update `KISA-website/client/package.json` to pinned new version
-7. `npm install` in client → lockfile syncs to new version
-8. Commit client version bump on a short-lived branch; open PR titled `chore(deps): bump @umichkisa-ds/web to X.Y.Z (mid-phase pre-consume for lane <id>)`
-
-When to schedule at plan-writing time:
-
-- If any lane's acceptance criteria reference a DS API added by an earlier lane in the same phase, insert a "Mid-phase bump" step in `plan.md` **immediately after** the producing DS lane and **before** the consuming client lane.
-- The consuming client lane then depends on the bump lane via `blocked-by:<issue-#>` (treat the mid-phase bump as a real lane with its own issue).
-- All bump lanes are `needs-interactive` — publish is hard-denied for autonomous per §9.
-
-Omission recovery: if plan-writing missed the mid-phase bump and the autonomous routine hits the gap (as happened for lane 0.5.5 on 2026-04-18), the consuming lane bails out with `needs-decision` per §6, you run the mid-phase bump interactively, then relabel the draft PR `needs-revision` so the next routine run finishes it.
+Same skill, fired in Mode E when `ds-fixes-log.md` has phase entries. Skill handles version bump + tag + publish + client repin.
 
 ---
 
-## 15. Skills Referenced
+# Part 5 — Amendment Log
 
-| Skill | Purpose |
-|---|---|
-| `grill-me` | Audit + plan grill sessions (Modes A, B) |
-| `ds-client-constrained-execution` | Lane execution (autonomous + interactive) |
-| `ds-fix-during-migration` | Mid-lane DS fixes |
-| `ds-phase-end-bump` | Phase close-out version bump + publish |
-| `using-git-worktrees` | Local worktree setup for interactive lanes (Mode D) |
-| `finishing-a-development-branch` | Final PR + merge for interactive lanes |
-| `review-pr-queue` | Mode C PR queue dispatcher (to be created) |
-| `ui-ux-pro-max` | Visual/design critique during live PR review |
-| `systematic-debugging` | Mode B `routine-errored` or complex CI-fail diagnosis |
-| `vercel-react-best-practices` | Final lane pass (per HARNESS) |
-| `toss-fe-review` agent | Per-task code-quality review (readability/predictability/cohesion/coupling), inserted between ds-client-review and typecheck |
-| `review-ui-on-browser` | Manual visual UI review via Playwright CLI on a running dev server. Used in Mode C (PR review) and Mode D (post-task) — never in autonomous routines |
-
----
-
-## 16. Setup Checklist (One-Time)
-
-Before the first autonomous run can happen:
-
-- [ ] Enable branch protection on `dev` in both repos (umichkisa-ds, KISA-website):
-  - Required status checks (typecheck, build, CI)
-  - Require 1 review approval
-  - No direct pushes
-  - Auto-delete merged branches
-- [ ] Create all label definitions in both GitHub repos (`ds-client-migration`, `phase-<N>`, `lane:*`, `autonomous-ready`, `needs-interactive`, `blocked-by:*`, `needs-decision`, `routine-errored`, `ready-for-review`, `needs-revision`)
-- [ ] Set `NEXT_PUBLIC_MOCK_API=1` in Vercel `dev` branch env vars (for Phase 0.5 hybrid auth — already noted in Phase 0 plan)
-- [ ] Configure Claude Code Routine via `schedule` skill:
-  - Target repo: `KISA-website/client` (for most lanes) or `umichkisa-ds` (for DS-side lanes)
-  - Cron: `0 17 * * *` UTC (= 02:00 KST, KST is UTC+9)
-  - Prompt: "Execute the autonomous ds-client-migration routine per `docs/plans/client-migration/AUTONOMOUS_PROTOCOL.md` §5"
-  - Permissions: restricted scope per §9
-- [ ] Verify first issue (a low-risk `[MECHANICAL]` trial lane) is labeled `autonomous-ready` with no blockers
-- [ ] Wait for first nightly run; review the morning output as the litmus test
-- [ ] If trial succeeds: label remaining eligible lanes as `autonomous-ready`
-- [ ] Create `review-pr-queue` skill (spec in §11)
-
----
-
-## 17. Trial Lane Recommendation
-
-First autonomous run should be the **lowest-risk, highest-observable lane** — a pure mechanical that produces a visible, reviewable diff but can't break much.
-
-**Phase 0.5 trial candidate: Lane 0.5.4a (Header cleanup & renames)**
-
-- `[MECHANICAL]` `[NO-TDD]`
-- Files: delete 8 dead files, rename 1 file, update imports
-- Self-contained, no behavioral change
-- Easy to verify: site still renders identically
-- If it fails, rollback is trivial (close PR, no merge)
-
-Do NOT trial with:
-- 0.5.1 (route groups — too many file moves for first test)
-- 0.5.2 (DS icon SVGs — involves cross-repo work)
-- 0.5.3 (auth infra — `needs-interactive` anyway)
-
----
-
-## 18. Simplification Levers (Future)
-
-Complexity to revisit if the protocol proves heavy in practice:
-
-1. **Drop mid-lane DS fixes** — batch all DS fixes at phase end instead. Removes §14a flow.
-2. **Fold `routine-errored` into `needs-decision`** — single bailout state.
-3. **Drop the 6-rule readiness gate; use scope tag only** — `[MECHANICAL]` + `[POLISH]` = autonomous-ready by default.
-4. **Skip revision flow (AP-Q14, §13)** — handle all revisions live in Mode B. Removes nightly revision cycle.
-5. **Single lane per nightly run instead of serial-all-eligible** — simpler, slower.
-6. **Skip `review-pr-queue` skill** — just use `gh pr list` manually in Mode B.
-
-Each lever trades complexity for speed or quality. Pick when the complexity stops earning its keep.
-
----
-
-## 19. Amendment Log
+## 14. Amendments
 
 | Date | Change | Reason |
 |---|---|---|
-| 2026-04-17 | Initial draft (13 AP questions + 3 follow-ups) | Phase 0.5 kickoff |
-| 2026-04-17 | Add post-merge label cleanup rule (§2, §8) — strip `ready-for-review` / `needs-revision` / `needs-decision` / `routine-errored` from PRs at merge time, since closed state replaces them | Surfaced during lane 0.5.2 review (PR #2 was merged with stale `ready-for-review` label) |
-| 2026-04-18 | Add §14c "Mid-phase pre-consume bump" — when a client lane consumes a DS addition produced by an earlier lane in the same phase, schedule an interactive patch-bump lane between them so the consuming lane's CI can install the new DS version | Surfaced during lane 0.5.5 autonomous run (PR #59): `instagram-brand` was on DS `main` after lane 0.5.2 merged, but the client pin was still `1.0.0` so the Icon name literal-type check failed in CI; §14b handles only phase-end bumps, leaving no legal path to unblock mid-phase |
+| 2026-04-17 | Initial draft | Phase 0.5 kickoff |
+| 2026-04-17 | Strip end-state labels at merge (§2, §10) | Lane 0.5.2 PR #2 merged with stale `ready-for-review` label |
+| 2026-04-18 | Add mid-phase pre-consume bump (§13) | Lane 0.5.5 (PR #59): client pin `1.0.0` predated `instagram-brand` icon merged in 0.5.2 |
+| 2026-04-25 | Split Mode C → C1/C2; Mode D → worktree off `dev` (`client/.worktrees/`); add §3.1 feedback-during-review and §3.2 parallel-terminal safety; restructure into Parts 1–5 for mode-slice contiguity; drop stale Setup Checklist + Trial Lane + Simplification Levers + ASCII routine flow + duplicate Detection subsection | User workflow review: PRs reviewed locally not on GitHub; Mode C and Mode D run in parallel terminals → directory collision |

--- a/docs/plans/client-migration/AUTONOMOUS_PROTOCOL.md
+++ b/docs/plans/client-migration/AUTONOMOUS_PROTOCOL.md
@@ -1,6 +1,13 @@
 # Autonomous Execution Protocol
 
-_Authoritative reference for the ds-client-migration autonomous execution harness. Loaded alongside `HARNESS_DESIGN.md`. Read at the start of any client-migration session — particularly Mode C (PR review) and Mode D (interactive execution) — per `CLAUDE.md` session protocol._
+_Authoritative reference for the ds-client-migration autonomous execution harness. Loaded alongside `HARNESS_DESIGN.md`. Read at the start of any client-migration session — particularly Modes C1/C2 (PR review) and Mode D (interactive execution) — per `CLAUDE.md` session protocol._
+
+> **For Claude:** This is operational reference. The cold-session protocol
+> in CLAUDE.md inlines the mode-detection logic from §10 — you do NOT need
+> to read this doc end-to-end on every session. Load specific sections
+> just-in-time per the mode you're in (Mode A → §3 + HARNESS phase flow;
+> Mode B → §3, §4; Mode C → `review-pr-queue` skill + §11; Mode D →
+> `ds-client-constrained-execution` skill; Mode E → §14 + HARNESS close-out).
 
 **Grill session:** 2026-04-17. All decisions locked in conversation; this doc is the artifact.
 
@@ -23,7 +30,7 @@ Guardrails exist to prevent: merging bad work, touching forbidden files, running
 | Actor | Role |
 |---|---|
 | You (Jioh In) | Audit author, plan author, label-gater, PR reviewer, merger, phase close-out |
-| Claude (interactive session) | Grill partner during audit/plan, lane executor in Mode D, PR reviewer in Mode B, debugger in Mode E |
+| Claude (interactive session) | Grill partner during audit/plan, lane executor in Mode D, PR reviewer in Modes C1/C2, debugger in Mode E |
 | Claude (autonomous routine) | Lane executor overnight, PR opener, `notes.md` appender, self-gated bailout |
 | GitHub | Issue queue, PR host, label-based state machine, CI runner, branch protector |
 
@@ -384,7 +391,12 @@ Phase 0.5 runs under this restricted scope. After 3 completed phases without an 
 
 ## 10. Cold-Session Modes (CLAUDE.md Session Protocol)
 
-When you start a Claude Code session and say "pick up the task," the cold-session protocol detects repo state and proposes one of five modes. You confirm; Claude proceeds.
+> **Detection logic now lives in `CLAUDE.md`.** This section remains as
+> the canonical reference for the modes themselves (mode flows, mode triggers).
+> The cold-session preflight in CLAUDE.md inlines the trigger-detection
+> rules so the session can route into a mode without reading this doc first.
+
+When you start a Claude Code session and say "pick up the task," the cold-session protocol detects repo state and proposes one of six modes (A, B, C1, C2, D, E). You confirm; Claude proceeds.
 
 ### Detection
 
@@ -404,9 +416,31 @@ On startup (post-HARNESS check and DS symlink check):
 |---|---|---|
 | **A. Audit writing** | `audit.md` missing | Grill-me session → write `audit.md` → wait for go-ahead |
 | **B. Plan writing + issue generation** | `audit.md` exists, `plan.md` missing | Grill (minor, as needed) → write `plan.md` → generate per-lane GitHub issues per §3 → apply labels → wait for go-ahead to enable routine |
-| **C. PR review** | Sitting PRs exist for phase | Invoke `review-pr-queue` skill (see §11) to group and present PRs; per-PR action per AP-Q3 matrix |
-| **D. Interactive execution** | `plan.md` exists, open `needs-interactive` issues without linked PRs, OR user overrides to execute live | Present wave lane menu (annotated per §12); user picks; worktree + `ds-client-constrained-execution` |
+| **C1. PR review — ready-to-merge** | Sitting PR(s); selected PR has neither `needs-decision` nor `needs-interactive` label, CI green | `review-pr-queue` → user picks → Claude `git fetch origin && git checkout <pr-branch>` in `../KISA-website/client/` (main clone) → Claude says "checked out, review when ready" and waits silently → user does local visual review → on "good" → `wrapping-up-pr`. If user gives feedback, see *Feedback during review* below. |
+| **C2. PR review — interactive/decision** | Sitting PR(s); selected PR has `needs-decision` or `needs-interactive` label | Same checkout flow as C1 → live discussion (grill-me / ui-ux-pro-max / systematic-debugging as needed) to resolve the pending question or judgment call → fix on branch → on "good" → `wrapping-up-pr`. |
+| **D. Interactive execution** | `plan.md` exists, open `needs-interactive` issues without linked PRs, OR user overrides to execute live | Present wave lane menu (annotated per §12); user picks; **create worktree off `dev` at `../KISA-website/client/.worktrees/<lane-id>/`** (nested, gitignored — keeps Mode D isolated from any parallel Mode C in the main clone) → `ds-client-constrained-execution`. |
 | **E. Phase close-out** | All lanes merged, phase marked ready | Check `ds-fixes-log.md` for phase entries; run `ds-phase-end-bump` if any; tick phase in TODO.md |
+
+#### Feedback during review (C1/C2)
+
+When the user gives feedback on a checked-out PR:
+
+- **Default — fix on the same branch.** Bugfixes, copy/styling tweaks, prop renames, single-file scope, anything inside the lane's stated audit scope. Commit and push to the same PR branch.
+- **Defer to a new lane** (propose, wait for confirm) when the fix:
+  - touches files outside the lane's audit scope, OR
+  - requires a DS change (then `ds-fix-during-migration` flow), OR
+  - adds a new feature/component not in the original lane.
+
+  Phrasing: "This feedback is out of scope for [lane-id] (reason: …). Defer to a new lane, or stretch this PR's scope?" Wait for explicit user choice.
+
+#### Parallel-terminal safety
+
+User may run Mode C and Mode D in different terminals at the same time. Isolation rule:
+
+- **Mode C uses the main client clone** (`../KISA-website/client/`) — checks out PR branches there. User reviews one PR at a time, so no internal collision.
+- **Mode D uses worktrees** under `../KISA-website/client/.worktrees/<lane-id>/`, always branched off `origin/dev`.
+
+This way the two modes never touch the same working directory.
 
 ### Protocol
 
@@ -435,14 +469,14 @@ When you start your daily availability window, this skill fetches all open auton
 ```markdown
 ### Today's PR queue (phase-0.5) — 5 open
 
-✅ **Skim-and-merge (3)** — CI green, no decisions pending
+✅ **Ready-to-merge / C1 (3)** — CI green, no decisions pending
 - [MECHANICAL] #43 [0.5.4a] Header cleanup — https://github.com/.../pull/43
 - [POLISH]     #44 [0.5.4f] MobileMenuButton — https://github.com/.../pull/44
 - [POLISH]     #45 [0.5.5]  Footer — https://github.com/.../pull/45
 
-🧐 **Needs live review (2)** — redesign, decision, or your comments
-- [REDESIGN]        #46 [0.5.4e] UserInfo (Avatar-only) — https://github.com/.../pull/46
-- [needs-decision]  #47 [0.5.4b] NavMenu (draft) — https://github.com/.../pull/47
+🧐 **Needs interactive review / C2 (2)** — `needs-decision` / `needs-interactive` label
+- [REDESIGN][needs-interactive]  #46 [0.5.4e] UserInfo (Avatar-only) — https://github.com/.../pull/46
+- [needs-decision]               #47 [0.5.4b] NavMenu (draft) — https://github.com/.../pull/47
     ↳ Question: "Should backdrop-blur be kept at 90% opacity or 80%?"
 
 ⚠️ **CI failing (0):** none
@@ -450,18 +484,19 @@ When you start your daily availability window, this skill fetches all open auton
 📝 **Needs revision (0):** none
 
 ---
-Pick a PR to start with, or say "skim and merge the ready ones" to batch-merge the green PRs.
+Pick a PR number to start with.
 ```
 
 ### Skill responsibilities
 
-1. Run `gh pr list` with phase + migration labels
-2. Classify each PR by labels and review state
-3. For `needs-decision` PRs, pull the question block from the PR body
-4. Present compact menu with URLs
-5. On user pick, hand off to appropriate flow:
-   - Skim-and-merge: open URL in browser (or offer `gh pr merge` command)
-   - Live review: enter Mode B flow (read diff, use grill-me / ui-ux-pro-max / systematic-debugging as needed)
+1. Run `gh pr list` with phase + migration labels.
+2. Classify each PR: `needs-decision` or `needs-interactive` label → C2; else CI-green → C1; CI-failing or `needs-revision` → separate buckets.
+3. For C2 PRs, pull the question block from the PR body.
+4. Present compact menu (numbers + URLs only — no "open in browser" or `gh pr merge` suggestions; user reviews locally).
+5. On user pick:
+   1. `cd ../KISA-website/client/ && git fetch origin && git checkout <pr-branch>` (main clone — Mode C never uses worktrees).
+   2. **C1:** print "Branch checked out at `<branch>` in `../KISA-website/client/`. Review when ready." Then wait silently. On user "good" → `wrapping-up-pr`. On feedback → apply *Feedback during review* rule (§10).
+   3. **C2:** print the same checkout confirmation, then surface the pending question / decision context and enter live discussion (grill-me / ui-ux-pro-max / systematic-debugging as needed).
 
 ### When invoked
 
@@ -633,6 +668,8 @@ Omission recovery: if plan-writing missed the mid-phase bump and the autonomous 
 | `ui-ux-pro-max` | Visual/design critique during live PR review |
 | `systematic-debugging` | Mode B `routine-errored` or complex CI-fail diagnosis |
 | `vercel-react-best-practices` | Final lane pass (per HARNESS) |
+| `toss-fe-review` agent | Per-task code-quality review (readability/predictability/cohesion/coupling), inserted between ds-client-review and typecheck |
+| `review-ui-on-browser` | Manual visual UI review via Playwright CLI on a running dev server. Used in Mode C (PR review) and Mode D (post-task) — never in autonomous routines |
 
 ---
 

--- a/docs/plans/client-migration/HARNESS_DESIGN.md
+++ b/docs/plans/client-migration/HARNESS_DESIGN.md
@@ -2,6 +2,11 @@
 
 Locked decisions from the grill session (2026-04-12). This is the authoritative reference for how the client migration runs. Read at the start of any migration session.
 
+> **For Claude:** This is a decisions reference doc, not a preflight load.
+> Consult on demand when (a) a harness decision is being challenged,
+> (b) a new phase is being planned, or (c) a mode-specific section is
+> referenced by a skill. Do NOT read end-to-end on every cold session.
+
 ---
 
 ## Slicing & Phases
@@ -51,9 +56,10 @@ All apps live under `umichkisa.com` in `../KISA-website/client/`.
 3. **Plan** — `writing-plans` skill produces `plan.md` with checkboxed tasks, each with a `**Files:**` section.
 
 4. **Execute** — `ds-client-constrained-execution` skill. One skill with two modes:
-   - `[NO-TDD]` tasks: implementer → ds-client-review → typecheck → commit
-   - `[TDD]` tasks: test-writer (red) → implementer (green) → ds-client-review → test verification → refactor → typecheck → commit
-   - Final pass: `vercel-react-best-practices` after all tasks complete
+   - `[NO-TDD]` tasks: implementer → ds-client-review → toss-fe-review → typecheck → commit
+   - `[TDD]` tasks: test-writer (red) → implementer (green) → ds-client-review → toss-fe-review → tests-green-verify → refactor → typecheck → commit
+   - Final pass after all tasks: `vercel-react-best-practices`
+   - Manual UI review: invoke `review-ui-on-browser` skill before merge for any UI-touching lane (run `npm run dev` first)
 
 5. **Verify** — manual via Vercel `dev`-branch preview URL (mocks on). Occasional chrome mcp on request.
 

--- a/docs/plans/client-migration/HARNESS_DESIGN.md
+++ b/docs/plans/client-migration/HARNESS_DESIGN.md
@@ -131,14 +131,17 @@ The user prefers to be challenged on assumptions rather than presented with a pr
 
 ---
 
-## Client Gate Tooling (created in Phase -1)
+## Client Gate Tooling
 
 | Artifact | Purpose |
 |---|---|
-| `docs/DS_CLIENT_USAGE.md` | Consumer-side constraint doc (what client code must/must-not do when consuming DS) |
-| `ds-client-review` agent | Reviews client `.tsx` against `DS_CLIENT_USAGE.md`, returns violations |
-| `ds-client-constrained-execution` skill | One skill, two modes (`[TDD]`/`[NO-TDD]`). Dispatches implementer + test-writer subagents, gates with ds-client-review, typechecks, commits. TDD mode modeled after `superpowers/skills/test-driven-development`. |
+| `docs/DS_CLIENT_USAGE.md` | Consumer-side constraint doc. Part 1 = write-time decision tree (implementer-facing); Part 2 = review-time rulebook (reviewer-facing). |
+| `ds-client-review` agent | Reviews client `.tsx` against `DS_CLIENT_USAGE.md`, returns violations. Reads its own ruleset (no caller paste). |
+| `toss-fe-review` agent | Per-task code-quality reviewer (readability / predictability / cohesion / coupling). BLOCK / SUGGEST / INFO severity gate; conservative defaults to avoid over-refactor. |
+| `ds-client-constrained-execution` skill | One skill, two modes (`[TDD]`/`[NO-TDD]`). Dispatches implementer + test-writer subagents, gates with `ds-client-review` then `toss-fe-review`, typechecks, commits. End-of-feature pass: `vercel-react-best-practices`. |
+| `review-ui-on-browser` skill | Manual visual UI/UX review via Playwright CLI on a running dev server. Used in Mode C (PR review) or Mode D (post-task) — never in autonomous routines. |
 | `ds-fix-during-migration` skill | Codifies the mid-phase DS bug-fix flow: pause client → fix DS → verify via symlink → accumulate for phase-end bump |
+| `ds-phase-end-bump` skill | Phase close-out + mid-phase pre-consume bump: bump DS package version, tag, publish, update client pin |
 | `client/scripts/link-ds.sh` | Re-establishes `npm link` for `@umichkisa-ds/web` + `@umichkisa-ds/form` |
 
 ### Why separate from existing DS tooling


### PR DESCRIPTION
## Summary

Tightens the ds-client-migration harness before Phase 3 audit kicks off. All decisions locked through grill-me on 2026-04-25; full plan committed to `docs/plans/2026-04-25-harness-improvements.md`.

## Changes

**Agents:**
- `ds-client-review` reads `docs/DS_CLIENT_USAGE.md` itself (drops caller paste; ~3K tokens/round saved in the orchestrator)
- New `toss-fe-review` agent — per-task code-quality review across 4 axes (readability / predictability / cohesion / coupling) with conservative `BLOCK / SUGGEST / INFO` severity gate

**Skills:**
- `ds-client-constrained-execution/SKILL.md` — wires `toss-fe-review` between `ds-client-review` and typecheck (NO-TDD) / tests-green-verify (TDD). Severity gate, 2-round hard stop. Trim from 216 → 150 lines.
- New `review-ui-on-browser` standalone skill — Playwright CLI on a running dev server. Manual invocation only (Vercel free-tier + auth makes embedding in autonomous routine impractical).

**Docs:**
- `DS_CLIENT_USAGE.md` restructured into Part 1 (write-time decision tree, available DS surface, tier picker, "what to use" rules, visibility/hierarchy rules absorbed from MEMORY) + Part 2 (full review-time rulebook with G1–G5 baked from Phase 2 evidence). 144 → 287 lines.
- `DS_CODEBASE.md` — pointer note redirects implementers to `DS_CLIENT_USAGE.md`
- `implementer-template.md` — write-time tier-justification pre-flight checklist before "Your Job"
- `HARNESS_DESIGN.md` + `AUTONOMOUS_PROTOCOL.md` — consult-on-demand banners; AP §15 registers new agent + skill; AP §10 notes mode detection moved to CLAUDE.md
- `CLAUDE.md` — preflight trimmed (TODO + symlink only) + inlined mode-detection table (incl. Mode C1/C2 split). HARNESS / AP / DS_CODEBASE moved to lazy-load per mode. 30+ → 65 lines (with structured tables).

## Test plan

- [x] `pnpm build` green (DS-side, all 3 tasks)
- [x] `pnpm typecheck` green (DS-side, all 5 tasks)
- [x] `DS_CLIENT_USAGE.md` has Part 1 / Part 2 structure
- [x] All required section headers present (Available DS Surface, Tier Picker, What to Use, Visibility & Hierarchy, G1)
- [x] All 7 referenced artifact files exist on branch
- [x] `SKILL.md` under 160-line trim cap (actual: 150)
- [ ] Phase 3 audit (Mode A) — first cold session that exercises new preflight; sanity-check on next pickup
- [ ] First Phase 3 lane that touches `.tsx` exercises new toss-fe-review per-task flow; verify behavior on first run